### PR TITLE
Add prometheus and grafana for observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ help:	## Show this help
 
 env: 	## Switch to an environment config
 	@mkdir -p config/active
-	cp config/${ENV}/*.env config/active/
+	rm -rf config/active/*
+	cp -r config/${ENV}/* config/active/
 
 bash:	## Opens bash shell in tooling container
 	$(COMPOSE_RUN_TOOLING) bash

--- a/config/dev/grafana.env
+++ b/config/dev/grafana.env
@@ -1,0 +1,2 @@
+GF_SECURITY_ADMIN_USER=osuchan
+GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_password

--- a/config/dev/secrets/grafana_admin_password
+++ b/config/dev/secrets/grafana_admin_password
@@ -1,0 +1,1 @@
+osuchan

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,3 +29,9 @@ services:
     build:
       target: production-runner
     restart: always
+
+  prometheus:
+    restart: always
+
+  grafana:
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ volumes:
   prometheus-data:
   grafana-data:
 
+secrets:
+  grafana_admin_password:
+    file: ./config/active/secrets/grafana_admin_password
+
 services:
   db:
     image: postgres:13
@@ -68,8 +72,6 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.45.0
-    ports:
-      - 9090:9090
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus:rw
@@ -78,5 +80,9 @@ services:
     image: grafana/grafana:10.0.2
     ports:
       - 3001:3000
+    env_file:
+      - ./config/active/grafana.env
     volumes:
       - grafana-data:/var/lib/grafana:rw
+    secrets:
+      - grafana_admin_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 # Services for running the application
 
+volumes:
+  queue-data:
+  prometheus-data:
+  grafana-data:
+
 services:
   db:
     image: postgres:13
@@ -12,6 +17,8 @@ services:
     image: rabbitmq:3-management
     env_file:
       - config/active/rabbitmq.env
+    volumes:
+      - queue-data:/var/lib/rabbitmq:rw
 
   cache:
     image: memcached:1
@@ -58,3 +65,18 @@ services:
       - config/active/django.env
     depends_on:
       - queue
+
+  prometheus:
+    image: prom/prometheus:v2.45.0
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus:rw
+
+  grafana:
+    image: grafana/grafana:10.0.2
+    ports:
+      - 3001:3000
+    volumes:
+      - grafana-data:/var/lib/grafana:rw

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -54,7 +54,9 @@ SECRET_KEY = env_settings.SECRET_KEY
 DEBUG = env_settings.DEBUG
 
 # NOTE: must not be empty when DEBUG is False
-ALLOWED_HOSTS = env_settings.ALLOWED_HOSTS
+ALLOWED_HOSTS = [
+    "api",  # hostname inside the docker network
+] + env_settings.ALLOWED_HOSTS
 
 CSRF_TRUSTED_ORIGINS = [env_settings.FRONTEND_URL]
 
@@ -81,6 +83,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "debug_toolbar",  # django debug toolbar
+    "django_prometheus",
     "osuauth.apps.OsuauthConfig",  # osu auth and accounts
     "users.apps.UsersConfig",  # api for users
     "profiles.apps.ProfilesConfig",  # api for profiles
@@ -88,6 +91,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -98,6 +102,7 @@ MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "middleware.logging.DiscordErrorLoggingMiddleware",
     "osuauth.middleware.LastActiveMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "osuchan.urls"
@@ -162,7 +167,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
+        "ENGINE": "django_prometheus.db.backends.postgresql",
         "NAME": env_settings.POSTGRES_DB_NAME,
         "USER": env_settings.POSTGRES_DB_USER,
         "PASSWORD": env_settings.POSTGRES_DB_PASSWORD,
@@ -177,7 +182,7 @@ DATABASES = {
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "BACKEND": "django_prometheus.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": f"{env_settings.MEMCACHED_HOST}:{env_settings.MEMCACHED_PORT}",
     }
 }

--- a/osuchan/urls.py
+++ b/osuchan/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path("api/leaderboards/", include("leaderboards.urls")),
     path("osuauth/", include("osuauth.urls")),
     path("beatmapfiles/<int:beatmap_id>", getBeatmapFile),
+    path("", include("django_prometheus.urls")),
 ]
 
 # Enable debug toolbar in debug mode

--- a/poetry.lock
+++ b/poetry.lock
@@ -475,6 +475,21 @@ django = ">=3.2.4"
 sqlparse = ">=0.2"
 
 [[package]]
+name = "django-prometheus"
+version = "2.3.1"
+description = "Django middlewares to monitor your application with Prometheus.io."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-prometheus-2.3.1.tar.gz", hash = "sha256:f9c8b6c780c9419ea01043c63a437d79db2c33353451347894408184ad9c3e1e"},
+    {file = "django_prometheus-2.3.1-py2.py3-none-any.whl", hash = "sha256:cf9b26f7ba2e4568f08f8f91480a2882023f5908579681bcf06a4d2465f12168"},
+]
+
+[package.dependencies]
+prometheus-client = ">=0.7"
+
+[[package]]
 name = "djangorestframework"
 version = "3.14.0"
 description = "Web APIs for Django, made easy."
@@ -1396,4 +1411,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e95566652a03979ac81cbf376e409a1774ac089202cfd5d73dd1d2b6999476f6"
+content-hash = "b0de5657eb2e5c1469fe8e3559077d3b63c5b7a3e7f8a64d7b6d87cc30941925"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: api
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - api:8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ rosu-pp-py = "^0.9.3"
 tqdm = "^4.64.0"
 flower = "^2.0.0"
 pydantic-settings = "^2.0.0"
+django-prometheus = "^2.3.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
## What?

Add prometheus and grafana for observability.

## Why?

Currently observability is cumbersome to use and not source controlled.

## Changes

- Add `django_prometheus` to expose `/metrics` endpoint (secured at ingress)
- Add prometheus container
- Add grafana container