### PR TITLE
Refresh global leaderboard top score cache on interval

### DIFF
--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -200,6 +200,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "profiles.tasks.dispatch_update_all_global_leaderboard_top_members",
         "schedule": crontab(minute=0, hour=0),  # midnight UTC
     },
+    "update-global-leaderboard-top-5-score-cache-every-10-minutes": {
+        "task": "leaderboards.tasks.update_global_leaderboard_top_5_score_cache",
+        "schedule": crontab(minute="*/10"),
+    },
 }
 
 


### PR DESCRIPTION
## What?

Add scheduled task to keep global leaderboard top score cache updated.

## Why?

Even with the page caching, the first load can time out on heavy leaderboards.
Using low level caching and a scheduled task to keep it up to date should resolve the slowness at the expense of data freshness.

## Changes

- Change the global leaderboard score cache to low level caching
- Add scheduled task to update global leaderboard score cache