### PR TITLE
Decrease frequency of lb score cache update task

### DIFF
--- a/leaderboards/tasks.py
+++ b/leaderboards/tasks.py
@@ -125,7 +125,7 @@ def update_global_leaderboard_top_5_score_cache():
             cache.set(
                 f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
                 scores,
-                900,
+                1800,
             )
 
 

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -288,7 +288,7 @@ class LeaderboardScoreList(APIView):
             scores = cache.get_or_set(
                 f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
                 lambda: leaderboard.get_top_scores(limit=limit),
-                900,
+                1800,
             )
         else:
             scores = leaderboard.get_top_scores(limit=5)

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -200,9 +200,9 @@ CELERY_BEAT_SCHEDULE = {
         "task": "profiles.tasks.dispatch_update_all_global_leaderboard_top_members",
         "schedule": crontab(minute=0, hour=0),  # midnight UTC
     },
-    "update-global-leaderboard-top-5-score-cache-every-10-minutes": {
+    "update-global-leaderboard-top-5-score-cache-every-20-minutes": {
         "task": "leaderboards.tasks.update_global_leaderboard_top_5_score_cache",
-        "schedule": crontab(minute="*/10"),
+        "schedule": crontab(minute="*/20"),
     },
 }
 


### PR DESCRIPTION
## What?

Decrease the frequency of the global leaderboard top 5 score cache update task.

## Why?

On the server, the task takes just over 15 minutes to run, which means at a 10 minute interval, it creates an ever-growing backlog and saturates the job queue.

## Changes

- Decrease frequency of the to 20 minutes
- Increase score cache timeout to 30 minutes