### PR TITLE
Split global leaderboard score cache task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./data/db:/var/lib/postgresql/data
     env_file:
       - config/active/postgres.env
+    shm_size: 128m
 
   queue:
     image: rabbitmq:3-management

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -201,7 +201,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=0, hour=0),  # midnight UTC
     },
     "update-global-leaderboard-top-5-score-cache-every-20-minutes": {
-        "task": "leaderboards.tasks.update_global_leaderboard_top_5_score_cache",
+        "task": "leaderboards.tasks.dispatch_update_global_leaderboard_top_5_score_cache",
         "schedule": crontab(minute="*/20"),
     },
 }


### PR DESCRIPTION
## What?

Split global leaderboard score cache update task into a single task per leaderboard, rather than all in one.

## Why?

Splitting the task decreases the time any given worker is blocked and allows us to:

- Process leaderboards in parallel
- Allow higher priority tasks to be processed first

## Changes

- Split global leaderboard score cache update task
- Increase db container `shm_size` (large queries are sometimes hitting the default 64MB limit)