### PR TITLE
Refactor out task dependencies in services

### DIFF
--- a/leaderboards/test_views.py
+++ b/leaderboards/test_views.py
@@ -245,7 +245,7 @@ class TestLeaderboardInviteList:
         url = reverse("leaderboard-invite-list", kwargs=kwargs)
         request = arf.post(
             url,
-            data={"user_ids": [osu_user.id], "message": "test message"},
+            data={"user_ids": [5701575], "message": "test message"},
             format="json",
         )
 

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -26,7 +26,7 @@ from leaderboards.services import (
 from profiles.enums import AllowedBeatmapStatus, ScoreSet
 from profiles.models import Score, ScoreFilter
 from profiles.serialisers import BeatmapScoreSerialiser, UserScoreSerialiser
-from profiles.services import refresh_user_from_api
+from profiles.tasks import update_user
 
 
 class LeaderboardList(APIView):
@@ -459,7 +459,7 @@ class LeaderboardInviteList(APIView):
                 invite = leaderboard.invites.get(user_id=invitee_id)
             except Invite.DoesNotExist:
                 # update profile to ensure they are in the database
-                refresh_user_from_api(user_id=invitee_id, gamemode=gamemode)
+                update_user(user_id=invitee_id, gamemode=gamemode)
 
                 invite = Invite(
                     user_id=invitee_id, leaderboard_id=leaderboard_id, message=message

--- a/profiles/management/commands/updateusers.py
+++ b/profiles/management/commands/updateusers.py
@@ -3,7 +3,7 @@ import os
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from profiles.services import refresh_user_from_api
+from profiles.tasks import update_user
 
 
 class Command(BaseCommand):
@@ -25,7 +25,7 @@ class Command(BaseCommand):
                 user_ids += fp.readlines()
 
         for user_id in user_ids:
-            user_stats = refresh_user_from_api(user_id=user_id, gamemode=gamemode)
+            user_stats = update_user(user_id=user_id, gamemode=gamemode)
 
             self.stdout.write(
                 self.style.SUCCESS(

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -223,13 +223,6 @@ def refresh_user_from_api(
         for score in created_scores:
             update_performance_calculation(score, difficulty_calculator)
 
-    # Update memberships
-    transaction.on_commit(
-        lambda: update_memberships.delay(
-            user_id=user_stats.user_id, gamemode=user_stats.gamemode
-        )
-    )
-
     return user_stats
 
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -16,8 +16,8 @@ from profiles.serialisers import (
     UserScoreSerialiser,
     UserStatsSerialiser,
 )
-from profiles.services import fetch_scores, fetch_user, refresh_user_from_api
-from profiles.tasks import update_user
+from profiles.services import fetch_scores, fetch_user
+from profiles.tasks import update_user, update_user_by_username
 
 
 class UserStatsDetail(APIView):
@@ -37,13 +37,13 @@ class UserStatsDetail(APIView):
             if user_id_type == "id":
                 user_stats = fetch_user(user_id=int(user_string), gamemode=gamemode)
                 if user_stats is None:
-                    user_stats = refresh_user_from_api(
+                    user_stats = update_user(
                         user_id=int(user_string), gamemode=gamemode
                     )
             elif user_id_type == "username":
                 user_stats = fetch_user(username=user_string, gamemode=gamemode)
                 if user_stats is None:
-                    user_stats = refresh_user_from_api(
+                    user_stats = update_user_by_username(
                         username=user_string, gamemode=gamemode
                     )
             else:


### PR DESCRIPTION
## Why?

This is a step towards a cleaner architecture with clear patterns and segregation of responsibilities.

- **views** and commands are entrypoints and should not be referenced by anything
- **tasks** are entrypoints but also represent high level units of work to be coordinated and thus can be used by views
- **services** are low level, specific routines that should not reach outside their domain
- **models** are purely database access

We aren't at this point just yet, but fixing the direction of dependency gets us closer.
The idea of what the ideal architecture looks like will probably also change, but I think this is a sensible north star for the time being.

## Changes

- Refactor `update_memberships` call out of `refresh_user_from_api`