### PR TITLE
Update to Difficalcy v0.8.0

### DIFF
--- a/common/osu/test_difficultycalculator.py
+++ b/common/osu/test_difficultycalculator.py
@@ -249,7 +249,7 @@ class TestDifficalcyDifficultyCalculator:
         assert DifficalcyOsuDifficultyCalculator.engine() == "osu.Game.Rulesets.Osu"
 
     def test_version(self):
-        assert DifficalcyOsuDifficultyCalculator.version() == "2024.412.1.0"
+        assert DifficalcyOsuDifficultyCalculator.version() == "2024.523.0.0"
 
     def test_context_manager(self):
         with DifficalcyOsuDifficultyCalculator() as calc:

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -31,6 +31,6 @@ services:
 
   difficalcy-osu:
     ports:
-      - 5000:80
+      - 6000:80
     volumes:
       - ./common/osu/stubdata/beatmap_provider:/beatmaps

--- a/compose.yaml
+++ b/compose.yaml
@@ -93,7 +93,7 @@ services:
       - grafana_admin_password
 
   difficalcy-osu:
-    image: ghcr.io/syriiin/difficalcy-osu:v0.7.0
+    image: ghcr.io/syriiin/difficalcy-osu:v0.8.0
     env_file:
       - config/active/difficalcy-osu.env
     environment:


### PR DESCRIPTION
## Why?

Better batching support.
Recalculations shouldn't kill the cache now.

## Changes

- Update difficalcy to v0.8.0
- Use port 6000 for local difficalcy exposure