### PR TITLE
Increase interval for leaderboard score cache

### DIFF
--- a/leaderboards/tasks.py
+++ b/leaderboards/tasks.py
@@ -51,7 +51,7 @@ def update_global_leaderboard_top_5_score_cache(leaderboard_id: int):
     cache.set(
         f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
         scores,
-        1800,
+        7200,
     )
     return scores
 

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -288,7 +288,7 @@ class LeaderboardScoreList(APIView):
             scores = cache.get_or_set(
                 f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
                 lambda: leaderboard.get_top_scores(limit=limit),
-                1800,
+                7200,
             )
         else:
             scores = leaderboard.get_top_scores(limit=limit)

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -204,9 +204,9 @@ CELERY_BEAT_SCHEDULE = {
         "task": "profiles.tasks.dispatch_update_all_global_leaderboard_top_members",
         "schedule": crontab(minute="0", hour="0"),  # midnight UTC
     },
-    "update-global-leaderboard-top-5-score-cache-every-20-minutes": {
+    "update-global-leaderboard-top-5-score-cache-every-hour": {
         "task": "leaderboards.tasks.dispatch_update_global_leaderboard_top_5_score_cache",
-        "schedule": crontab(minute="*/20"),
+        "schedule": crontab(minute="0"),
     },
     "update-loved-beatmaps-every-month": {
         "task": "profiles.tasks.update_loved_beatmaps",


### PR DESCRIPTION
## Why?

It's hammering the server big time, and we are working to remove it soon anyway.

## Changes

- Increase `dispatch_update_global_leaderboard_top_5_score_cache` schedule to hourly
- Increase leaderboard score cache timeout to 2 hours