### PR TITLE
Fix update_membership() keeping outdated scores

### DIFF
--- a/leaderboards/services.py
+++ b/leaderboards/services.py
@@ -119,6 +119,11 @@ def update_membership(leaderboard: Leaderboard, user_id: int):
         unique_fields=["membership_id", "score_id"],
     )
 
+    outdated_membershipscores = MembershipScore.objects.filter(
+        membership=membership
+    ).exclude(score_id__in=[score.id for score in scores])
+    outdated_membershipscores.delete()
+
     membership.score_count = len(membership_scores)
 
     membership.pp = calculate_pp_total(


### PR DESCRIPTION
## Why?

There are cases where a score might be removed from a membership.
The usual case for this is when the member supercedes it with a better score on the same beatmap.
This can also happen if there are bugs that cause incorrect scores to get added in the first place, or the leaderboard score filter is manually adjusted.
Either way, we want `update_membership()` to ensure the membership is fully valid and up to date, including scores.

## Changes

- Remove outdated scores from memberships in `update_membership()`