### PR TITLE
Remove global leaderboard top score cache and task

### DIFF
--- a/leaderboards/tasks.py
+++ b/leaderboards/tasks.py
@@ -35,28 +35,6 @@ def update_memberships(user_id, gamemode=Gamemode.STANDARD):
 
 
 @shared_task
-def dispatch_update_global_leaderboard_top_5_score_cache():
-    for gamemode in Gamemode:
-        leaderboards = Leaderboard.objects.filter(
-            access_type=LeaderboardAccessType.GLOBAL, gamemode=gamemode
-        )
-        for leaderboard in leaderboards:
-            update_global_leaderboard_top_5_score_cache.delay(leaderboard.id)
-
-
-@shared_task
-def update_global_leaderboard_top_5_score_cache(leaderboard_id: int):
-    leaderboard = Leaderboard.objects.get(id=leaderboard_id)
-    scores = leaderboard.get_top_scores(limit=5)
-    cache.set(
-        f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
-        scores,
-        7200,
-    )
-    return scores
-
-
-@shared_task
 def send_leaderboard_top_score_notification(leaderboard_id: int, score_id: int):
     # passing score_id instead of querying for top score in case it changes before the job is picked up
 

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -284,14 +284,7 @@ class LeaderboardScoreList(APIView):
         except Leaderboard.DoesNotExist:
             raise NotFound("Leaderboard not found.")
 
-        if leaderboard.access_type == LeaderboardAccessType.GLOBAL:
-            scores = cache.get_or_set(
-                f"leaderboards::global_leaderboard_top_5_scores::{leaderboard.id}",
-                lambda: leaderboard.get_top_scores(limit=limit),
-                7200,
-            )
-        else:
-            scores = leaderboard.get_top_scores(limit=limit)
+        scores = leaderboard.get_top_scores(limit=limit)
 
         serialiser = LeaderboardScoreSerialiser(scores, many=True)
         return Response(serialiser.data)

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -209,10 +209,6 @@ CELERY_BEAT_SCHEDULE = {
             "cooldown_seconds": timedelta(hours=12).total_seconds(),
         },
     },
-    "update-global-leaderboard-top-5-score-cache-every-hour": {
-        "task": "leaderboards.tasks.dispatch_update_global_leaderboard_top_5_score_cache",
-        "schedule": crontab(minute="0"),
-    },
     "update-loved-beatmaps-every-month": {
         "task": "profiles.tasks.update_loved_beatmaps",
         "schedule": crontab(minute="0", hour="0", day_of_month="1"),

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -15,7 +15,6 @@ from common.osu.difficultycalculator import (
 from common.osu.difficultycalculator import Score as DifficultyCalculatorScore
 from common.osu.enums import BeatmapStatus, Gamemode, Mods
 from leaderboards.models import Leaderboard, Membership
-from leaderboards.tasks import update_memberships
 from profiles.models import (
     Beatmap,
     DifficultyCalculation,


### PR DESCRIPTION
## Why?

The changes to the top score query should make it lightning fast now, so the cache should be unnecessary.

## Changes

- Remove global leaderboard top 5 score cache
- Remove scheduled task to update score cache

## Notes

Leaving this for a day or so just to make sure nothing unexpected happens.