### PR TITLE
Delete unloved beatmap files along with db rows

### DIFF
--- a/common/osu/beatmap_provider.py
+++ b/common/osu/beatmap_provider.py
@@ -16,6 +16,10 @@ class AbstractBeatmapProvider(ABC):
     def get_beatmap_file(self, beatmap_id: str) -> str:
         raise NotImplementedError()
 
+    @abstractmethod
+    def delete_beatmap(self, beatmap_id: str):
+        raise NotImplementedError()
+
 
 class LiveBeatmapProvider(AbstractBeatmapProvider):
     def get_beatmap_file(self, beatmap_id: str) -> str:
@@ -31,6 +35,11 @@ class LiveBeatmapProvider(AbstractBeatmapProvider):
                 )
 
         return beatmap_path
+
+    def delete_beatmap(self, beatmap_id: str):
+        beatmap_path = os.path.join(settings.BEATMAP_CACHE_PATH, f"{beatmap_id}.osu")
+        if os.path.isfile(beatmap_path):
+            os.remove(beatmap_path)
 
 
 class StubBeatmapProvider(AbstractBeatmapProvider):
@@ -48,6 +57,9 @@ class StubBeatmapProvider(AbstractBeatmapProvider):
             )
 
         return beatmap_path
+
+    def delete_beatmap(self, beatmap_id: str):
+        pass
 
 
 BeatmapProvider: Type[AbstractBeatmapProvider] = import_string(

--- a/profiles/management/commands/recalculate.py
+++ b/profiles/management/commands/recalculate.py
@@ -346,7 +346,7 @@ class Command(BaseCommand):
             initial=initial,
             smoothing=0,
         ) as pbar:
-            for unique_beatmap in unique_beatmaps:
+            for unique_beatmap in tqdm(unique_beatmaps, desc="Unique beatmaps"):
                 unique_beatmap_scores = scores_to_recalculate.filter(
                     beatmap_id=unique_beatmap["beatmap_id"], mods=unique_beatmap["mods"]
                 )

--- a/profiles/tasks.py
+++ b/profiles/tasks.py
@@ -3,6 +3,7 @@ import time
 
 from celery import shared_task
 
+from common.osu.beatmap_provider import BeatmapProvider
 from common.osu.enums import BeatmapStatus, Gamemode
 from leaderboards.models import Leaderboard
 from leaderboards.tasks import update_memberships
@@ -91,6 +92,8 @@ def update_loved_beatmaps():
                 f"Beatmap {beatmap.id} appears to have been unloved. Deleting..."
             )
             beatmap.delete()
+            beatmap_provider = BeatmapProvider()
+            beatmap_provider.delete_beatmap(str(beatmap.id))
             return None
 
         outdated_scores = updated_beatmap.scores.filter(


### PR DESCRIPTION
## Why?

If the map gets reloved in the future, the beatmap file might have changed.
Perhaps we could also just verify the beatmap hash, but this will work for now.

## Changes

- Delete beatmap files along with db rows for unloved beatmaps