### PR TITLE
Fix empty profile updates causing full database recalculations

### DIFF
--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -332,9 +332,13 @@ class AbstractDifficalcyDifficultyCalculator(AbstractDifficultyCalculator):
             )
             response.raise_for_status()
             data = response.json()
+        except httpx.HTTPStatusError as e:
+            raise CalculationException(
+                f"An error occured in calculating the beatmap {score.beatmap_id}: {e.request.url} [{e.response.status_code}] {e.response.text}"
+            ) from e
         except httpx.HTTPError as e:
             raise CalculationException(
-                f"An error occured in calculating the beatmap {score.beatmap_id}: [{e.response.status_code}] {e.response.text}"
+                f"An error occured in calculating the beatmap {score.beatmap_id}: {e.request.url} - {e}"
             ) from e
 
         return Calculation(
@@ -350,9 +354,13 @@ class AbstractDifficalcyDifficultyCalculator(AbstractDifficultyCalculator):
             )
             response.raise_for_status()
             data = response.json()
-        except httpx.HTTPError as e:
+        except httpx.HTTPStatusError as e:
             raise CalculationException(
                 f"An error occured in calculating the beatmaps {set(score.beatmap_id for score in scores)}: [{e.response.status_code}] {e.response.text}"
+            ) from e
+        except httpx.HTTPError as e:
+            raise CalculationException(
+                f"An error occured in calculating the beatmaps {set(score.beatmap_id for score in scores)}: {e}"
             ) from e
 
         return [

--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -311,7 +311,7 @@ class AbstractDifficalcyDifficultyCalculator(AbstractDifficultyCalculator):
     def __init__(self):
         super().__init__()
 
-        self.client = httpx.Client(timeout=120.0)
+        self.client = httpx.Client(timeout=20.0)
 
     def _close(self):
         self.client.close()

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -551,7 +551,9 @@ def update_performance_calculations(
         unique_fields=["beatmap_id", "mods", "calculator_engine"],
     )
     # TODO: remove when bulk_create(update_conflicts) returns pks in django 5.0
-    unique_beatmap_query = Q()
+    unique_beatmap_query = Q(
+        pk__in=[]  # ensures no-op if somehow there are no unique beatmaps
+    )
     for beatmap_id, mods in unique_beatmaps:
         unique_beatmap_query |= Q(beatmap_id=beatmap_id, mods=mods)
     difficulty_calculations = DifficultyCalculation.objects.filter(

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -232,10 +232,11 @@ def refresh_user_from_api(
     # Process and add scores
     created_scores = add_scores_from_data(user_stats, score_data_list)
 
-    difficulty_calculators = get_difficulty_calculators_for_gamemode(gamemode)
-    for difficulty_calculator in difficulty_calculators:
-        with difficulty_calculator() as calc:
-            update_performance_calculations(created_scores, calc)
+    if len(created_scores) > 0:
+        difficulty_calculators = get_difficulty_calculators_for_gamemode(gamemode)
+        for difficulty_calculator in difficulty_calculators:
+            with difficulty_calculator() as calc:
+                update_performance_calculations(created_scores, calc)
 
     return user_stats
 


### PR DESCRIPTION
## Why?

That escalated quickly!

## Changes

- Fix unique beatmap query to default to an empty query instead of EVERYTHING
- Short circuit profile updates to skip diffcalc if no new scores were added
- Lower difficalcy timeout
- Improve difficalcy error handling