### PR TITLE
Expose new diffcalc models

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -73,6 +73,8 @@ services:
     env_file:
       - config/active/django.env
       - config/active/flower.env
+    volumes:
+      - beatmaps:/beatmaps
     depends_on:
       - worker
 
@@ -81,6 +83,8 @@ services:
     command: celery --app osuchan beat --loglevel info --schedule /tmp/celerybeat-schedule
     env_file:
       - config/active/django.env
+    volumes:
+      - beatmaps:/beatmaps
     depends_on:
       - queue
 

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -284,7 +284,10 @@ class LeaderboardScoreList(APIView):
         except Leaderboard.DoesNotExist:
             raise NotFound("Leaderboard not found.")
 
-        scores = leaderboard.get_top_scores(limit=limit)
+        scores = leaderboard.get_top_scores(limit=limit).prefetch_related(
+            "performance_calculations__performance_values",
+            "performance_calculations__difficulty_calculation__difficulty_values",
+        )
 
         serialiser = LeaderboardScoreSerialiser(scores, many=True)
         return Response(serialiser.data)
@@ -551,6 +554,10 @@ class LeaderboardBeatmapScoreList(APIView):
             .filter(membership__leaderboard_id=leaderboard_id, beatmap_id=beatmap_id)
             .select_related("user_stats", "user_stats__user")
             .get_score_set(leaderboard.gamemode, score_set=leaderboard.score_set)
+            .prefetch_related(
+                "performance_calculations__performance_values",
+                "performance_calculations__difficulty_calculation__difficulty_values",
+            )
         )
         serialiser = BeatmapScoreSerialiser(scores[:50], many=True)
         return Response(serialiser.data)
@@ -586,6 +593,10 @@ class LeaderboardMemberScoreList(APIView):
             )
             .select_related("beatmap")
             .get_score_set(leaderboard.gamemode, score_set=leaderboard.score_set)
+            .prefetch_related(
+                "performance_calculations__performance_values",
+                "performance_calculations__difficulty_calculation__difficulty_values",
+            )
         )
         serialiser = UserScoreSerialiser(scores[:100], many=True)
         return Response(serialiser.data)

--- a/profiles/serialisers.py
+++ b/profiles/serialisers.py
@@ -1,6 +1,16 @@
 from rest_framework import serializers
 
-from profiles.models import Beatmap, OsuUser, Score, ScoreFilter, UserStats
+from profiles.models import (
+    Beatmap,
+    DifficultyCalculation,
+    DifficultyValue,
+    OsuUser,
+    PerformanceCalculation,
+    PerformanceValue,
+    Score,
+    ScoreFilter,
+    UserStats,
+)
 
 
 class OsuUserSerialiser(serializers.ModelSerializer):
@@ -43,6 +53,27 @@ class UserStatsSerialiser(serializers.ModelSerializer):
         )
 
 
+class DifficultyValueSerialiser(serializers.ModelSerializer):
+    class Meta:
+        model = DifficultyValue
+        fields = (
+            "name",
+            "value",
+        )
+
+
+class DifficultyCalculationSerialiser(serializers.ModelSerializer):
+    difficulty_values = DifficultyValueSerialiser(many=True)
+
+    class Meta:
+        model = DifficultyCalculation
+        fields = (
+            "calculator_engine",
+            "calculator_version",
+            "difficulty_values",
+        )
+
+
 class BeatmapSerialiser(serializers.ModelSerializer):
     class Meta:
         model = Beatmap
@@ -74,7 +105,32 @@ class BeatmapSerialiser(serializers.ModelSerializer):
         )
 
 
+class PerformanceValueSerialiser(serializers.ModelSerializer):
+    class Meta:
+        model = PerformanceValue
+        fields = (
+            "name",
+            "value",
+        )
+
+
+class PerformanceCalculationSerialiser(serializers.ModelSerializer):
+    performance_values = PerformanceValueSerialiser(many=True)
+    difficulty_calculation = DifficultyCalculationSerialiser()
+
+    class Meta:
+        model = PerformanceCalculation
+        fields = (
+            "calculator_engine",
+            "calculator_version",
+            "performance_values",
+            "difficulty_calculation",
+        )
+
+
 class ScoreSerialiser(serializers.ModelSerializer):
+    performance_calculations = PerformanceCalculationSerialiser(many=True)
+
     class Meta:
         model = Score
         fields = (
@@ -102,6 +158,7 @@ class ScoreSerialiser(serializers.ModelSerializer):
             # relations
             "beatmap",
             "user_stats",
+            "performance_calculations",
             # convenience fields
             "gamemode",
             "accuracy",

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -144,6 +144,10 @@ class UserScoreList(APIView):
             .filter(user_stats__user_id=user_id, user_stats__gamemode=gamemode)
             .apply_score_filter(score_filter)
             .get_score_set(gamemode, score_set)
+            .prefetch_related(
+                "performance_calculations__performance_values",
+                "performance_calculations__difficulty_calculation__difficulty_values",
+            )
         )
 
         serialiser = UserScoreSerialiser(scores[:100], many=True)


### PR DESCRIPTION
## Why?

Last step to phasing out the old fields is replacing their usage in the frontend.

## Changes

- Add nested `performance_calculations` field to serialised scores