### PR TITLE
Increase difficalcy timeout again to 180 seconds

### DIFF
--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -311,7 +311,7 @@ class AbstractDifficalcyDifficultyCalculator(AbstractDifficultyCalculator):
     def __init__(self):
         super().__init__()
 
-        self.client = httpx.Client(timeout=120.0)
+        self.client = httpx.Client(timeout=180.0)
 
     def _close(self):
         self.client.close()


### PR DESCRIPTION
## Why?

We are still hitting the timeout on recalculation batches with particularly long unique beatmaps (eg. save me with a bunch of different mod combos)