### PR TITLE
Handle diffcalc errors

### DIFF
--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -11,7 +11,7 @@ from django.utils.module_loading import import_string
 from oppaipy.oppaipy import OppaiError
 
 from common.osu.beatmap_provider import BeatmapNotFoundException, BeatmapProvider
-from common.osu.enums import Gamemode, Mods
+from common.osu.enums import Gamemode
 
 OPPAIPY_VERSION = metadata.version("oppaipy")
 ROSUPP_VERSION = metadata.version("rosu_pp_py")

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -668,7 +668,20 @@ def calculate_difficulty_values(
         for difficulty_calculation in difficulty_calculations
     ]
 
-    results = difficulty_calculator.calculate_score_batch(calc_scores)
+    results = []
+    try:
+        results.extend(difficulty_calculator.calculate_score_batch(calc_scores))
+    except DifficultyCalculatorException as e:
+        error_reporter = ErrorReporter()
+        error_reporter.report_error(e)
+
+        # Batch failed, so let's try one by one to get as many values as possible
+        for calc_score in calc_scores:
+            try:
+                results.append(difficulty_calculator.calculate_score(calc_score))
+            except DifficultyCalculatorException as e:
+                error_reporter.report_error(e)
+                results.append(None)
 
     values = [
         [
@@ -680,6 +693,7 @@ def calculate_difficulty_values(
             for name, value in result.difficulty_values.items()
         ]
         for difficulty_calculation, result in zip(difficulty_calculations, results)
+        if result is not None
     ]
 
     return values
@@ -706,7 +720,20 @@ def calculate_performance_values(
         for performance_calculation in performance_calculations
     ]
 
-    results = difficulty_calculator.calculate_score_batch(calc_scores)
+    results = []
+    try:
+        results.extend(difficulty_calculator.calculate_score_batch(calc_scores))
+    except DifficultyCalculatorException as e:
+        error_reporter = ErrorReporter()
+        error_reporter.report_error(e)
+
+        # Batch failed, so let's try one by one to get as many values as possible
+        for calc_score in calc_scores:
+            try:
+                results.append(difficulty_calculator.calculate_score(calc_score))
+            except DifficultyCalculatorException as e:
+                error_reporter.report_error(e)
+                results.append(None)
 
     values = [
         [
@@ -715,9 +742,10 @@ def calculate_performance_values(
                 name=name,
                 value=value,
             )
+            for name, value in result.performance_values.items()
         ]
         for performance_calculation, result in zip(performance_calculations, results)
-        for name, value in result.performance_values.items()
+        if result is not None
     ]
 
     return values

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -270,15 +270,22 @@ def refresh_beatmaps_from_api(beatmap_ids: Iterable[int]):
         with get_default_difficulty_calculator_class(
             Gamemode(beatmap.gamemode)
         )() as calc:
-            calculation = calc.calculate_score(
-                DifficultyCalculatorScore(
-                    mods=Mods.NONE.value,
-                    beatmap_id=str(beatmap.id),
+            try:
+                calculation = calc.calculate_score(
+                    DifficultyCalculatorScore(
+                        mods=Mods.NONE.value,
+                        beatmap_id=str(beatmap.id),
+                    )
                 )
-            )
-            beatmap.difficulty_total = calculation.difficulty_values["total"]
-            beatmap.difficulty_calculator_engine = calc.engine()
-            beatmap.difficulty_calculator_version = calc.version()
+                beatmap.difficulty_total = calculation.difficulty_values["total"]
+                beatmap.difficulty_calculator_engine = calc.engine()
+                beatmap.difficulty_calculator_version = calc.version()
+            except DifficultyCalculatorException as e:
+                error_reporter = ErrorReporter()
+                error_reporter.report_error(e)
+                beatmap.difficulty_total = 0
+                beatmap.difficulty_calculator_engine = calc.engine()
+                beatmap.difficulty_calculator_version = calc.engine()
 
         beatmaps.append(beatmap)
 
@@ -429,8 +436,8 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[dict]):
         score.user_stats = user_stats
 
         # Calculate performance total
-        try:
-            with get_default_difficulty_calculator_class(gamemode)() as calc:
+        with get_default_difficulty_calculator_class(gamemode)() as calc:
+            try:
                 calculation = calc.calculate_score(
                     DifficultyCalculatorScore(
                         mods=score.mods,
@@ -447,13 +454,13 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[dict]):
                 score.difficulty_total = calculation.difficulty_values["total"]
                 score.difficulty_calculator_engine = calc.engine()
                 score.difficulty_calculator_version = calc.version()
-        except DifficultyCalculatorException as e:
-            error_reporter = ErrorReporter()
-            error_reporter.report_error(e)
-            score.performance_total = 0
-            score.difficulty_total = 0
-            score.difficulty_calculator_engine = "error"
-            score.difficulty_calculator_version = "error"
+            except DifficultyCalculatorException as e:
+                error_reporter = ErrorReporter()
+                error_reporter.report_error(e)
+                score.performance_total = 0
+                score.difficulty_total = 0
+                score.difficulty_calculator_engine = calc.engine()
+                score.difficulty_calculator_version = calc.engine()
 
         # Update convenience fields
         score.gamemode = user_stats.gamemode


### PR DESCRIPTION
## Why?

Since we only do diffcalc in batches for recalc, an error in a single score scraps the whole batch.
If this happens, we want to just retry each score of the batch individually

## Changes

- Retry batch calcs one by one if a batch fails
- Clean up handling of legacy diffcalc fields (even though we're about to remove them)