### PR TITLE
Fix the first score on a leaderboard not being considered a pp record

### DIFF
--- a/leaderboards/models.py
+++ b/leaderboards/models.py
@@ -84,9 +84,11 @@ class Leaderboard(models.Model):
     def get_pp_record(self) -> float:
         scores = self.get_top_scores()
 
-        return scores.aggregate(Max("membership_scores__performance_total"))[
+        max_pp = scores.aggregate(Max("membership_scores__performance_total"))[
             "membership_scores__performance_total__max"
         ]
+
+        return max_pp if max_pp is not None else 0
 
     def get_top_scores(self, limit=5):
         return self.scores.order_by(

--- a/leaderboards/services.py
+++ b/leaderboards/services.py
@@ -130,8 +130,7 @@ def update_membership(leaderboard: Leaderboard, user_id: int):
     if leaderboard.notification_discord_webhook_url != "":
         # Check for new top score
         if (
-            pp_record is not None
-            and len(membership_scores) > 0
+            len(membership_scores) > 0
             and membership_scores[0].performance_total > pp_record
         ):
             # NOTE: need to use a function with default params here so the closure has the correct variables


### PR DESCRIPTION
## Why?

The first score on a leaderboard _should_ be considered a pp record.

## Changes

- Fix `get_pp_record()` returning `None` if there are no scores instead of `0`