### PR TITLE
Add redis.conf for difficalcy to limit memory

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ volumes:
   cache-data:
   difficalcy-cache-data:
 
+
 secrets:
   grafana_admin_password:
     file: ./config/active/secrets/grafana_admin_password
@@ -143,5 +144,7 @@ services:
 
   difficalcy-cache:
     image: redis:7
+    command: redis-server /usr/local/etc/redis/redis.conf
     volumes:
+      - ./config/active/difficalcy-redis.conf:/usr/local/etc/redis/redis.conf
       - difficalcy-cache-data:/data

--- a/config/dev/difficalcy-redis.conf
+++ b/config/dev/difficalcy-redis.conf
@@ -1,0 +1,2 @@
+maxmemory 100mb
+maxmemory-policy allkeys-lru


### PR DESCRIPTION
## Why?

We don't set expiry for difficalcy keys, so we should be limiting memory and using an eviction policy to keep our memory in check.

## Changes

- Add `redis.conf` for difficalcy-cache
    - Limit memory to 100mb
    - Use LRU algorithm to evict keys