### PR TITLE
Set 250MB max memory for celery worker processes

### DIFF
--- a/leaderboards/services.py
+++ b/leaderboards/services.py
@@ -4,7 +4,6 @@ from rest_framework.exceptions import PermissionDenied
 from common.osu.utils import calculate_pp_total
 from leaderboards.enums import LeaderboardAccessType
 from leaderboards.models import Leaderboard, Membership, MembershipScore
-from profiles.enums import ScoreResult, ScoreSet
 from profiles.models import OsuUser, Score
 
 

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -205,6 +205,7 @@ CELERY_BROKER_URL = f"amqp://{env_settings.CELERY_USER}:{env_settings.CELERY_PAS
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_WORKER_MAX_MEMORY_PER_CHILD = 250000  # 250MB TODO: investigate this memory leak
 
 CELERY_BEAT_SCHEDULE = {
     "update-top-global-members-every-day": {


### PR DESCRIPTION
## Why?

There is a memory leak somewhere (almost certainly in the `update_user` task, maybe diffcalc?) that is killing strangling the server and killing the workers in the middle of tasks.

## Changes

- Add 250MB limit to celery worker processes