### PR TITLE
Add metrics for postgres and rabbitmq to prometheus

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -5,6 +5,10 @@ services:
     ports:
       - 5432:5432
 
+  queue:
+    ports:
+      - 15672:15672
+
   api:
     build:
       target: development-runner
@@ -30,6 +34,10 @@ services:
     command: watchmedo auto-restart --pattern=*.py --recursive -- celery --app osuchan beat --loglevel info --schedule /tmp/celerybeat-schedule
     volumes:
       - .:/app
+
+  prometheus:
+    ports:
+      - 9090:9090
 
   difficalcy-osu:
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,11 @@ services:
       - config/active/postgres.env
     shm_size: 128m
 
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    env_file:
+      - config/active/postgres-exporter.env
+
   queue:
     image: rabbitmq:3-management
     env_file:

--- a/config/dev/postgres-exporter.env
+++ b/config/dev/postgres-exporter.env
@@ -1,0 +1,3 @@
+DATA_SOURCE_URI=db:5432/osuchan?sslmode=disable
+DATA_SOURCE_USER=osuchan
+DATA_SOURCE_PASS=osuchan

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -8,3 +8,9 @@ scrape_configs:
     static_configs:
       - targets:
           - api:8000
+
+  - job_name: queue
+    metrics_path: /metrics/per-object
+    static_configs:
+      - targets:
+          - queue:15692

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -14,3 +14,9 @@ scrape_configs:
     static_configs:
       - targets:
           - queue:15692
+
+  - job_name: postgres
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - postgres-exporter:9187


### PR DESCRIPTION
## Why?

Observability is good.

## Changes

- Add postgres exporter
- Add rabbitmq and postgres as prometheus targets