### PR TITLE
Use difficalcy-osu as the default osu calculator

### DIFF
--- a/leaderboards/test_services.py
+++ b/leaderboards/test_services.py
@@ -35,7 +35,7 @@ class TestMembershipServices:
         )
         membership = leaderboard.memberships.first()
         assert membership.score_count == 4
-        assert membership.pp == 1239.8257144523454
+        assert membership.pp == 1239.449243038565
 
     @pytest.fixture
     def membership(self, leaderboard, stub_user_stats):
@@ -46,10 +46,10 @@ class TestMembershipServices:
         assert membership.leaderboard.member_count == 2
         assert membership.user.username == "Syrin"
         assert membership.score_count == 4
-        assert membership.pp == 1215.8880634205632
+        assert membership.pp == 1215.5272384251844
 
     def test_update_membership(self, membership):
         fetch_scores(membership.user_id, [362949], Gamemode.STANDARD)
         membership = update_membership(membership.leaderboard, membership.user_id)
         assert membership.score_count == 5
-        assert membership.pp == 1399.645425686207
+        assert membership.pp == 1399.2214430030024

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -338,7 +338,7 @@ DIFFICULTY_CALCULATOR_CLASSES = {
 }
 
 DEFAULT_DIFFICULTY_CALCULATORS = {
-    Gamemode.STANDARD: "rosupp",
+    Gamemode.STANDARD: "difficalcy-osu",
     Gamemode.TAIKO: "difficalcy-taiko",
     Gamemode.CATCH: "difficalcy-catch",
     Gamemode.MANIA: "difficalcy-mania",


### PR DESCRIPTION
## Why?

We want to get rid of oppai and rosupp now as they are redundant.

## Changes

- Switch to `difficalcy-osu` as the default calculator for osu