### PR TITLE
Fix leaderboard notifications occuring on recalc

### DIFF
--- a/leaderboards/management/commands/refreshleaderboard.py
+++ b/leaderboards/management/commands/refreshleaderboard.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
                 else:
                     users = leaderboard.members.all().values("id")
                 for user_id in tqdm([u["id"] for u in users]):
-                    update_membership(leaderboard, user_id)
+                    update_membership(leaderboard, user_id, skip_notifications=True)
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/leaderboards/services.py
+++ b/leaderboards/services.py
@@ -43,7 +43,9 @@ def delete_membership(membership):
 
 
 @transaction.atomic
-def update_membership(leaderboard: Leaderboard, user_id: int):
+def update_membership(
+    leaderboard: Leaderboard, user_id: int, skip_notifications: bool = False
+):
     """
     Creates or updates a membership for a given user on a given leaderboard
     """
@@ -131,7 +133,7 @@ def update_membership(leaderboard: Leaderboard, user_id: int):
 
     membership.save()
 
-    if leaderboard.notification_discord_webhook_url != "":
+    if not skip_notifications and leaderboard.notification_discord_webhook_url != "":
         # Check for new top score
         if (
             len(membership_scores) > 0

--- a/profiles/management/commands/recalculate.py
+++ b/profiles/management/commands/recalculate.py
@@ -268,7 +268,11 @@ class Command(BaseCommand):
         with tqdm(desc="Memberships", total=memberships.count(), smoothing=0) as pbar:
             for page in paginator:
                 for membership in page:
-                    update_membership(membership.leaderboard, membership.user_id)
+                    update_membership(
+                        membership.leaderboard,
+                        membership.user_id,
+                        skip_notifications=True,
+                    )
                     pbar.update()
                 Membership.objects.bulk_update(page, ["pp"])
 


### PR DESCRIPTION
## Why?

When we do a recalc, depending on the order of the recalc there could be many incorrect notifications fired.
Best to disable notifications for recalcs.

## Changes

- Disable leaderboard notifications when performing a recalc