### PR TITLE
Improve restricted user handling

### DIFF
--- a/leaderboards/models.py
+++ b/leaderboards/models.py
@@ -93,9 +93,11 @@ class Leaderboard(models.Model):
         return max_pp if max_pp is not None else 0
 
     def get_top_scores(self, limit=5):
-        return self.scores.order_by(
-            "-membership_scores__performance_total", "date"
-        ).select_related("user_stats", "user_stats__user", "beatmap")[:limit]
+        return (
+            self.scores.non_restricted()
+            .order_by("-membership_scores__performance_total", "date")
+            .select_related("user_stats", "user_stats__user", "beatmap")[:limit]
+        )
 
     def get_top_membership(self):
         if self.access_type == LeaderboardAccessType.GLOBAL:

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -99,7 +99,9 @@ def refresh_user_from_api(
         else:
             # User either doesnt exist, is restricted, or name changed
             try:
-                osu_user = OsuUser.objects.select_for_update().get(username=username)
+                osu_user = OsuUser.objects.select_for_update().get(
+                    username__iexact=username
+                )
                 # Fetch from osu api with user id incase of name change
                 user_data = osu_api_v1.get_user_by_id(osu_user.id, gamemode)
 


### PR DESCRIPTION
## Why?

Restricted user handling is a pain.
It would be super simple if false restrictions didn't exist, but since they do, we need to make sure we don't delete scores for restricted users, in case they get unrestricted soon after.
Anyway, until we have a better way of handling false restrictions we'll need to stick with this `non_restricted()` query system.

## Changes

- Fix leaderboard top scores including restricted users