### PR TITLE
Update to django 5

### DIFF
--- a/leaderboards/urls.py
+++ b/leaderboards/urls.py
@@ -1,10 +1,6 @@
-from django.urls import path, register_converter
+from django.urls import path
 
-from common.converters import GamemodeConverter, LeaderboardTypeConverter
 from leaderboards import views
-
-register_converter(GamemodeConverter, "gm")
-register_converter(LeaderboardTypeConverter, "lb_type")
 
 urlpatterns = [
     path(

--- a/osuchan/urls.py
+++ b/osuchan/urls.py
@@ -2,9 +2,13 @@ from django.conf import settings
 from django.conf.urls import include
 from django.contrib import admin
 from django.http import Http404, HttpResponse
-from django.urls import path
+from django.urls import path, register_converter
 
+from common.converters import GamemodeConverter, LeaderboardTypeConverter
 from common.osu.beatmap_provider import BeatmapNotFoundException, BeatmapProvider
+
+register_converter(GamemodeConverter, "gm")
+register_converter(LeaderboardTypeConverter, "lb_type")
 
 
 def getBeatmapFile(request, beatmap_id):

--- a/poetry.lock
+++ b/poetry.lock
@@ -440,17 +440,17 @@ toml = ["tomli"]
 
 [[package]]
 name = "django"
-version = "4.2.15"
+version = "5.1"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "Django-4.2.15-py3-none-any.whl", hash = "sha256:61ee4a130efb8c451ef3467c67ca99fdce400fedd768634efc86a68c18d80d30"},
-    {file = "Django-4.2.15.tar.gz", hash = "sha256:c77f926b81129493961e19c0e02188f8d07c112a1162df69bfab178ae447f94a"},
+    {file = "Django-5.1-py3-none-any.whl", hash = "sha256:d3b811bf5371a26def053d7ee42a9df1267ef7622323fe70a601936725aa4557"},
+    {file = "Django-5.1.tar.gz", hash = "sha256:848a5980e8efb76eea70872fb0e4bc5e371619c70fffbe48e3e1b50b2c09455d"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.6.0,<4"
+asgiref = ">=3.8.1,<4"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -1393,4 +1393,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "55ce3bb016f919acabebeb877ea0c8ff1b0370a9172b766fb33df7f051ed5633"
+content-hash = "e0cb69abf8abd3b15bae53f777a966a6b2295b6e51dbca38b58f06a616204daa"

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -1,10 +1,6 @@
-from django.urls import path, register_converter
+from django.urls import path
 
-from common.converters import GamemodeConverter, LeaderboardTypeConverter
 from profiles import views
-
-register_converter(GamemodeConverter, "gm")
-register_converter(LeaderboardTypeConverter, "lb_type")
 
 urlpatterns = [
     path(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.12"
 celery = "^5.2.7"
-Django = "^4.2.3"
+Django = "^5.1"
 djangorestframework = "^3.12.4"
 django-debug-toolbar = "^4.1.0"
 gunicorn = "^22.0.0"


### PR DESCRIPTION
## Why?

Now that we have upgraded from python 3.9 we can upgrade django too!

## Changes

- Update to django 5.1
- Resolve new deprecation warnings