### PR TITLE
Improve diffcalc handling to ensure outdated values are updated or removed

### DIFF
--- a/profiles/services.py
+++ b/profiles/services.py
@@ -455,7 +455,6 @@ def update_difficulty_calculations(
     """
     # Create calculations
     calculations = []
-    beatmap_ids = []
     for beatmap in beatmaps:
         calculations.append(
             DifficultyCalculation(
@@ -465,19 +464,12 @@ def update_difficulty_calculations(
                 calculator_version=difficulty_calculator.version(),
             )
         )
-        beatmap_ids.append(beatmap.id)
 
     DifficultyCalculation.objects.bulk_create(
         calculations,
         update_conflicts=True,
         update_fields=["calculator_version"],
         unique_fields=["beatmap_id", "mods", "calculator_engine"],
-    )
-    # TODO: remove when bulk_create(update_conflicts) returns pks in django 5.0
-    calculations = DifficultyCalculation.objects.filter(
-        beatmap_id__in=beatmap_ids,
-        mods=Mods.NONE,
-        calculator_engine=difficulty_calculator.engine(),
     )
 
     values = calculate_difficulty_values(calculations, difficulty_calculator)
@@ -521,16 +513,6 @@ def update_performance_calculations(
         update_fields=["calculator_version"],
         unique_fields=["beatmap_id", "mods", "calculator_engine"],
     )
-    # TODO: remove when bulk_create(update_conflicts) returns pks in django 5.0
-    unique_beatmap_query = Q(
-        pk__in=[]  # ensures no-op if somehow there are no unique beatmaps
-    )
-    for beatmap_id, mods in unique_beatmaps:
-        unique_beatmap_query |= Q(beatmap_id=beatmap_id, mods=mods)
-    difficulty_calculations = DifficultyCalculation.objects.filter(
-        unique_beatmap_query,
-        calculator_engine=difficulty_calculator.engine(),
-    )
 
     # Do difficulty calculations
     difficulty_values = calculate_difficulty_values(
@@ -546,7 +528,6 @@ def update_performance_calculations(
     )
 
     # Create or update performance calculations
-    score_ids = []
     performance_calculations = []
     for score in scores:
         difficulty_calculation = next(
@@ -563,7 +544,6 @@ def update_performance_calculations(
                 calculator_version=difficulty_calculator.version(),
             )
         )
-        score_ids.append(score.id)
 
     PerformanceCalculation.objects.bulk_create(
         performance_calculations,
@@ -571,11 +551,6 @@ def update_performance_calculations(
         update_fields=["calculator_version", "difficulty_calculation_id"],
         unique_fields=["score_id", "calculator_engine"],
     )
-    # TODO: remove when bulk_create(update_conflicts) returns pks in django 5.0
-    performance_calculations = PerformanceCalculation.objects.filter(
-        score_id__in=score_ids,
-        calculator_engine=difficulty_calculator.engine(),
-    ).select_related("score")
 
     # Do performance calculations
     performance_values = calculate_performance_values(

--- a/profiles/test_services.py
+++ b/profiles/test_services.py
@@ -68,6 +68,16 @@ class TestUserServices:
 @pytest.mark.django_db
 class TestDifficultyCalculationServices:
     def test_update_difficulty_calculations(self, beatmap):
+        calculation = DifficultyCalculation.objects.create(
+            beatmap=beatmap,
+            mods=Mods.NONE,
+            calculator_engine="osu.Game.Rulesets.Osu",
+            calculator_version="2007.906.0",
+        )
+
+        calculation.difficulty_values.create(name="aim", value=0.05)
+        calculation.difficulty_values.create(name="dummy", value=9001)
+
         with get_default_difficulty_calculator_class(
             Gamemode.STANDARD
         )() as difficulty_calculator:
@@ -89,6 +99,26 @@ class TestDifficultyCalculationServices:
         assert difficulty_values[3].value == 6.710442985146793
 
     def test_update_performance_calculations(self, score):
+        difficulty_calculation = DifficultyCalculation.objects.create(
+            beatmap=score.beatmap,
+            mods=score.mods,
+            calculator_engine="osu.Game.Rulesets.Osu",
+            calculator_version="2007.906.0",
+        )
+
+        difficulty_calculation.difficulty_values.create(name="aim", value=0.05)
+        difficulty_calculation.difficulty_values.create(name="dummy", value=9001)
+
+        calculation = PerformanceCalculation.objects.create(
+            score=score,
+            difficulty_calculation=difficulty_calculation,
+            calculator_engine="osu.Game.Rulesets.Osu",
+            calculator_version="2007.906.0",
+        )
+
+        calculation.performance_values.create(name="aim", value=5.05)
+        calculation.performance_values.create(name="dummy", value=900001)
+
         with get_default_difficulty_calculator_class(
             Gamemode.STANDARD
         )() as difficulty_calculator:


### PR DESCRIPTION
## Why?

Currently if a calculator is updated to remove a value, the existing calculations would still keep it, because we were only doing upserts.
We need to make sure we also remove any old outdated values.
This may not be the most efficient way to handle this, but it is the cleanest code.
If this is a performance hit, we can move to some sort of cleanup post-recalc where we delete all values for a calculator that don't match a value name given by the calc.

## Changes

- Remove unnecessary (since django 5) refetch from db for pks
- Delete old diffcalc values when recalculating
- Add test to ensure old diffcalc values are removed correctly