### PR TITLE
Add grouping to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "poetry"
+      ],
+      "matchDepTypes": [
+        "dev-dependencies"
+      ],
+      "groupName": "poetry-dev-dependencies"
+    },
+    {
+      "matchManagers": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "/difficalcy/"
+      ],
+      "groupName": "difficalcy"
+    }
   ]
 }


### PR DESCRIPTION
## Why?

Groups are convenient!

## Changes

- Add renovate groups for:
    - difficalcy
    - python dev deps