### PR TITLE
Revert "Update postgres Docker tag to v17"

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ secrets:
 
 services:
   db:
-    image: postgres:17
+    image: postgres:16
     volumes:
       - db-data:/var/lib/postgresql/data
     env_file:


### PR DESCRIPTION
Reverts Syriiin/osuchan-backend#139

The prometheus postgres-exporter doesn't fully support pg 17 yet, so let's hold off until then.