### PR TITLE
Update to python3.13 in pyproject.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN ${POETRY_PATH}/bin/pip install poetry==${POETRY_VERSION}
 # Install dependencies
 WORKDIR ${APPDEPS_PATH}
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-dev
+RUN poetry install --only main
 
 # --------------------------------------------------------------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -949,10 +949,7 @@ files = [
 [package.dependencies]
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
-typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
-]
+typing-extensions = {version = ">=4.12.2", markers = "python_version >= \"3.13\""}
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -1471,5 +1468,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "54d4742d1ab1c3c1ef6653a0fec6a48bf44d42b78281f914950c91e386037d1c"
+python-versions = "^3.13"
+content-hash = "109e19f029314cd84c8eb3a2402b52464db543d669ff577d57a9a7076c148595"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "AGPL-3.0"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.13"
 celery = "^5.2.7"
 Django = "^5.1"
 djangorestframework = "^3.12.4"

--- a/scripts/restoredb
+++ b/scripts/restoredb
@@ -8,6 +8,8 @@ fi
 
 docker compose up -d db
 
+sleep 5 # wait for db to boot
+
 docker compose exec -T db dropdb \
     --username=osuchan \
     osuchan


### PR DESCRIPTION
## Why?

Renovate updated the dockerfile to use python3.13, but it missed updating in pyproject.toml

## Changes

- Update to python3.13 in `pyproject.toml`
- Add 5 second sleep to restoredb script to allow db to boot
- Switch from deprecated poetry `--no-dev` flag to `--only main`