### PR TITLE
Fix cases where NC with no DT mod causes crashes

### DIFF
--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -277,9 +277,9 @@ def get_mods_string(mods: int):
         if mod & mods:
             mod_strings.append(mod_acronyms[mod])
 
-    if Mods.NIGHTCORE & mods:
+    if Mods.NIGHTCORE & mods and "DT" in mod_strings:
         mod_strings.remove("DT")
-    if Mods.PERFECT & mods:
+    if Mods.PERFECT & mods and "SD" in mod_strings:
         mod_strings.remove("SD")
 
     return ",".join(mod_strings)


### PR DESCRIPTION
## Why?

This shouldn't be possible, but for some reason it appears the api returns some scores with NC, but not DT.