### PR TITLE
Use json hit statistics 

### DIFF
--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -1,9 +1,9 @@
 from common.osu.enums import Gamemode, Mods
 from common.osu.utils import (
     calculate_pp_total,
-    get_accuracy,
     get_ar,
     get_bpm,
+    get_classic_accuracy,
     get_cs,
     get_gamemode_from_gamemode_string,
     get_gamemode_string_from_gamemode,
@@ -20,44 +20,51 @@ def test_calculate_pp_total():
 
 def test_get_accuracy():
     assert (
-        get_accuracy(
-            count_300=1739,
-            count_100=14,
-            count_50=0,
-            count_miss=0,
+        get_classic_accuracy(
+            statistics={
+                "great": 1739,
+                "ok": 14,
+                "meh": 0,
+                "miss": 0,
+            },
             gamemode=Gamemode.STANDARD,
         )
         == 99.4675793877163
     )
     assert (
-        get_accuracy(
-            count_300=2950,
-            count_100=14,
-            count_50=0,
-            count_miss=0,
+        get_classic_accuracy(
+            statistics={
+                "great": 2950,
+                "ok": 14,
+                "miss": 0,
+            },
             gamemode=Gamemode.TAIKO,
         )
         == 99.7638326585695
     )
     assert (
-        get_accuracy(
-            count_300=4431,
-            count_100=109,
-            count_50=0,
-            count_miss=0,
-            count_katu=2,
+        get_classic_accuracy(
+            statistics={
+                "great": 4431,
+                "large_tick_hit": 109,
+                "small_tick_hit": 0,
+                "miss": 0,
+                "small_tick_miss": 2,
+            },
             gamemode=Gamemode.CATCH,
         )
         == 99.95596653456627
     )
     assert (
-        get_accuracy(
-            count_300=2724,
-            count_100=26,
-            count_50=17,
-            count_miss=37,
-            count_katu=171,
-            count_geki=7853,
+        get_classic_accuracy(
+            statistics={
+                "perfect": 7853,
+                "great": 2724,
+                "good": 171,
+                "ok": 26,
+                "meh": 17,
+                "miss": 37,
+            },
             gamemode=Gamemode.MANIA,
         )
         == 98.84096786110085

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -8,80 +8,54 @@ def calculate_pp_total(sorted_pps):
     return sum(pp * (0.95**i) for i, pp in enumerate(sorted_pps))
 
 
-def get_accuracy(
-    count_300,
-    count_100,
-    count_50,
-    count_miss,
-    count_katu=None,
-    count_geki=None,
+def get_classic_accuracy(
+    statistics: dict[str, int],
     gamemode=Gamemode.STANDARD,
 ):
-    # ---------------Acc calculations
-    # Accuracy = (Total points of hits / (Total number of hits * 300) * 100)
-    # Total points of hits = (Number of 50s * 50 + Number of 100s * 100 + Number of 300s * 300)
-    # Total number of hits = (Number of misses + Number of 50's + Number of 100's + Number of 300's)
+    if gamemode == Gamemode.STANDARD:
+        great = statistics.get("great", 0)
+        ok = statistics.get("ok", 0)
+        meh = statistics.get("meh", 0)
+        miss = statistics.get("miss", 0)
+
+        max_points = 300 * (great + ok + meh + miss)
+        points = (50 * meh) + (100 * ok) + (300 * great)
+
+    elif gamemode == Gamemode.TAIKO:
+        great = statistics.get("great", 0)
+        ok = statistics.get("ok", 0)
+        miss = statistics.get("miss", 0)
+
+        max_points = 300 * (great + ok + miss)
+        points = 300 * ((0.5 * ok) + great)
+
+    elif gamemode == Gamemode.CATCH:
+        great = statistics.get("great", 0)
+        large_tick_hit = statistics.get("large_tick_hit", 0)
+        small_tick_hit = statistics.get("small_tick_hit", 0)
+        small_tick_miss = statistics.get("small_tick_miss", 0)
+        miss = statistics.get("miss", 0)
+
+        max_points = great + large_tick_hit + small_tick_hit + miss + small_tick_miss
+        points = great + large_tick_hit + small_tick_hit
+
+    elif gamemode == Gamemode.MANIA:
+        perfect = statistics.get("perfect", 0)
+        great = statistics.get("great", 0)
+        good = statistics.get("good", 0)
+        ok = statistics.get("ok", 0)
+        meh = statistics.get("meh", 0)
+        miss = statistics.get("miss", 0)
+
+        max_points = 300 * (meh + ok + good + great + perfect + miss)
+        points = (
+            (meh * 50) + (ok * 100) + (good * 200) + (great * 300) + (perfect * 300)
+        )
+    else:
+        raise ValueError(f"{gamemode} is not a valid gamemode")
 
     try:
-        if gamemode == Gamemode.STANDARD:
-            # standard acc
-            no_300 = int(count_300)
-            no_100 = int(count_100)
-            no_50 = int(count_50)
-            no_miss = int(count_miss)
-
-            total_hits = no_300 + no_100 + no_50 + no_miss
-            points = (no_50 * 50) + (no_100 * 100) + (no_300 * 300)
-
-            accuracy = (points / (total_hits * 300)) * 100
-
-        elif gamemode == Gamemode.TAIKO:
-            # taiko acc
-            no_300 = int(count_300)
-            no_100 = int(count_100)
-            no_miss = int(count_miss)
-
-            total_hits = no_300 + no_100 + no_miss
-            points = ((no_100 * 0.5) + (no_300 * 1)) * 300
-
-            accuracy = (points / (total_hits * 300)) * 100
-
-        elif gamemode == Gamemode.CATCH:
-            # ctb acc
-            no_300 = int(count_300)
-            no_100 = int(count_100)
-            no_50 = int(count_50)
-            no_miss = int(count_miss)
-            no_drop_miss = int(count_katu)
-
-            total_hits = no_300 + no_100 + no_50 + no_miss + no_drop_miss
-            caught = no_300 + no_100 + no_50
-
-            accuracy = (caught / total_hits) * 100
-
-        elif gamemode == Gamemode.MANIA:
-            # mania acc
-            no_MAX = int(count_geki)
-            no_300 = int(count_300)
-            no_200 = int(count_katu)
-            no_100 = int(count_100)
-            no_50 = int(count_50)
-            no_miss = int(count_miss)
-
-            total_hits = no_50 + no_100 + no_200 + no_300 + no_MAX + no_miss
-            points = (
-                (no_50 * 50)
-                + (no_100 * 100)
-                + (no_200 * 200)
-                + (no_300 * 300)
-                + (no_MAX * 300)
-            )
-
-            accuracy = (points / (total_hits * 300)) * 100
-        else:
-            raise ValueError(f"{gamemode} is not a valid gamemode")
-
-        return accuracy
+        return 100 * (points / max_points)
     except ZeroDivisionError:
         return 0
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -559,14 +559,12 @@ class Score(models.Model):
         score.count_100 = self.count_100
         score.count_50 = self.count_50
         score.count_miss = 0
-        score.statistics = (
-            {
-                "great": score.count_300,
-                "ok": score.count_100,
-                "meh": score.count_50,
-                "miss": score.count_miss,
-            },
-        )
+        score.statistics = {
+            "great": score.count_300,
+            "ok": score.count_100,
+            "meh": score.count_50,
+            "miss": score.count_miss,
+        }
         score.best_combo = self.beatmap.max_combo
         score.perfect = True
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -571,13 +571,8 @@ class Score(models.Model):
         score.perfect = True
 
         # Calculate new accuracy
-        score.accuracy = utils.get_accuracy(
-            score.count_300,
-            score.count_100,
-            score.count_50,
-            score.count_miss,
-            score.count_katu,
-            score.count_geki,
+        score.accuracy = utils.get_classic_accuracy(
+            score.statistics,
             gamemode=gamemode,
         )
         if score.accuracy == 1:

--- a/profiles/serialisers.py
+++ b/profiles/serialisers.py
@@ -142,6 +142,7 @@ class ScoreSerialiser(serializers.ModelSerializer):
             "count_miss",
             "count_geki",
             "count_katu",
+            "statistics",
             "best_combo",
             "perfect",
             "mods",

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -353,13 +353,8 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
 
         # Update convenience fields
         score.gamemode = gamemode
-        score.accuracy = utils.get_accuracy(
-            score.count_300,
-            score.count_100,
-            score.count_50,
-            score.count_miss,
-            score.count_katu,
-            score.count_geki,
+        score.accuracy = utils.get_classic_accuracy(
+            score.statistics,
             gamemode=gamemode,
         )
         score.bpm = utils.get_bpm(score.beatmap.bpm, score.mods)


### PR DESCRIPTION
## Why?

We've added the json statistics, now we need to use them

## Changes

- Use json hit statistics instead of legacy fields
- Expose json statistics to api
- Fix bug with nochoke json statistics being wrapped in `[]`