### PR TITLE
Improve lazer score support

### DIFF
--- a/common/osu/osuapi.py
+++ b/common/osu/osuapi.py
@@ -699,7 +699,7 @@ class LiveOsuApiV2(AbstractOsuApi):
             beatmap_id=beatmap_id,
             mods=bitwise_mods,
             is_classic=is_classic,
-            score=score.legacy_total_score,
+            score=score.legacy_total_score if is_classic else score.total_score,
             best_combo=score.max_combo,
             count_300=count_300,
             count_100=count_100,

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -49,7 +49,7 @@ def get_classic_accuracy(
 
         max_points = 300 * (meh + ok + good + great + perfect + miss)
         points = (
-            (meh * 50) + (ok * 100) + (good * 200) + (great * 300) + (perfect * 300)
+            (50 * meh) + (100 * ok) + (200 * good) + (300 * great) + (300 * perfect)
         )
     else:
         raise ValueError(f"{gamemode} is not a valid gamemode")

--- a/leaderboards/services.py
+++ b/leaderboards/services.py
@@ -78,9 +78,10 @@ def update_membership(
             rank=leaderboard.member_count + 1,
         )
 
-    # Get leaderboard records before updating, so we can compare
-    pp_record = leaderboard.get_pp_record()
-    leaderboard_top_player = leaderboard.get_top_membership()
+    if not skip_notifications and leaderboard.notification_discord_webhook_url != "":
+        # Get leaderboard records before updating, so we can compare for notifications
+        pp_record = leaderboard.get_pp_record()
+        leaderboard_top_player = leaderboard.get_top_membership()
 
     scores = Score.objects.filter(
         user_stats__user_id=user_id, user_stats__gamemode=leaderboard.gamemode

--- a/profiles/management/commands/recalculatestats.py
+++ b/profiles/management/commands/recalculatestats.py
@@ -1,0 +1,88 @@
+from django.core.management.base import BaseCommand
+from django.core.paginator import Paginator
+from django.db.models import QuerySet
+from tqdm import tqdm
+
+from common.osu.enums import Gamemode
+from leaderboards.models import Membership
+from leaderboards.services import update_membership
+from profiles.models import UserStats
+
+
+class Command(BaseCommand):
+    help = "Recalculates user stats score styles and memberships"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--gamemode",
+            type=int,
+            help="Gamemode to recalculate stats for",
+            choices=[Gamemode.STANDARD, Gamemode.TAIKO, Gamemode.CATCH, Gamemode.MANIA],
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        gamemode = Gamemode(options["gamemode"])
+
+        # Recalculate user stats
+        all_user_stats = UserStats.objects.filter(gamemode=gamemode)
+        self.recalculate_user_stats(all_user_stats)
+
+        # Recalculate memberships
+        memberships = Membership.objects.select_related("leaderboard").filter(
+            leaderboard__gamemode=gamemode
+        )
+        self.recalculate_memberships(memberships)
+
+    def recalculate_user_stats(
+        self,
+        all_user_stats: QuerySet[UserStats],
+    ):
+        paginator = Paginator(all_user_stats.order_by("pk"), per_page=2000)
+
+        with tqdm(desc="User Stats", total=all_user_stats.count(), smoothing=0) as pbar:
+            for page in paginator:
+                for user_stats in page:
+                    user_stats.recalculate()
+                    pbar.update()
+                UserStats.objects.bulk_update(
+                    page,
+                    [
+                        "extra_pp",
+                        "score_style_accuracy",
+                        "score_style_bpm",
+                        "score_style_length",
+                        "score_style_cs",
+                        "score_style_ar",
+                        "score_style_od",
+                    ],
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully updated {all_user_stats.count()} user stats"
+            )
+        )
+
+    def recalculate_memberships(
+        self,
+        memberships: QuerySet[Membership],
+    ):
+        paginator = Paginator(memberships.order_by("pk"), per_page=2000)
+
+        with tqdm(desc="Memberships", total=memberships.count(), smoothing=0) as pbar:
+            for page in paginator:
+                for membership in page:
+                    update_membership(
+                        membership.leaderboard,
+                        membership.user_id,
+                        skip_notifications=True,
+                    )
+                    pbar.update()
+                Membership.objects.bulk_update(page, ["pp"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully updated {memberships.count()} memberships"
+            )
+        )

--- a/profiles/management/commands/refetchlazerscores.py
+++ b/profiles/management/commands/refetchlazerscores.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from tqdm import tqdm
 
 from common.osu.enums import Gamemode
-from profiles.models import Score
+from profiles.models import UserStats
 from profiles.services import fetch_scores
 
 
@@ -14,71 +14,23 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        self.refetch_lazer_scores_osu()
-        self.refetch_lazer_scores_taiko()
-        self.refetch_lazer_scores_catch()
-        self.refetch_lazer_scores_mania()
+        self.refetch_lazer_scores(Gamemode.STANDARD)
+        self.refetch_lazer_scores(Gamemode.TAIKO)
+        self.refetch_lazer_scores(Gamemode.CATCH)
+        self.refetch_lazer_scores(Gamemode.MANIA)
 
-    def refetch_lazer_scores_osu(self):
-        scores = Score.objects.filter(
-            gamemode=Gamemode.STANDARD, is_classic=False, statistics={}
-        ).order_by("id")
+    def refetch_lazer_scores(self, gamemode: Gamemode):
+        user_stats = UserStats.objects.filter(gamemode=gamemode).order_by("id")
 
-        for score in tqdm(scores, desc="STANDARD", smoothing=0):
+        for stats in tqdm(user_stats, desc=gamemode.name, smoothing=0):
             # Sleep for 100ms to avoid rate limiting
             time.sleep(0.1)
 
-            user_id = score.user_stats.user_id
-            beatmap_id = score.beatmap_id
-            gamemode = score.gamemode
+            beatmap_ids = list(
+                stats.scores.filter(is_classic=False)
+                .values_list("beatmap_id", flat=True)
+                .distinct()
+            )
+            stats.scores.filter(beatmap_id__in=beatmap_ids, is_classic=False).delete()
 
-            score.delete()
-            fetch_scores(user_id, [beatmap_id], gamemode)
-
-    def refetch_lazer_scores_taiko(self):
-        scores = Score.objects.filter(
-            gamemode=Gamemode.TAIKO, is_classic=False, statistics={}
-        ).order_by("id")
-
-        for score in tqdm(scores, desc="TAIKO", smoothing=0):
-            # Sleep for 100ms to avoid rate limiting
-            time.sleep(0.1)
-
-            user_id = score.user_stats.user_id
-            beatmap_id = score.beatmap_id
-            gamemode = score.gamemode
-
-            score.delete()
-            fetch_scores(user_id, [beatmap_id], gamemode)
-
-    def refetch_lazer_scores_catch(self):
-        scores = Score.objects.filter(
-            gamemode=Gamemode.CATCH, is_classic=False, statistics={}
-        ).order_by("id")
-
-        for score in tqdm(scores, desc="CATCH", smoothing=0):
-            # Sleep for 100ms to avoid rate limiting
-            time.sleep(0.1)
-
-            user_id = score.user_stats.user_id
-            beatmap_id = score.beatmap_id
-            gamemode = score.gamemode
-
-            score.delete()
-            fetch_scores(user_id, [beatmap_id], gamemode)
-
-    def refetch_lazer_scores_mania(self):
-        scores = Score.objects.filter(
-            gamemode=Gamemode.MANIA, is_classic=False, statistics={}
-        ).order_by("id")
-
-        for score in tqdm(scores, desc="MANIA", smoothing=0):
-            # Sleep for 100ms to avoid rate limiting
-            time.sleep(0.1)
-
-            user_id = score.user_stats.user_id
-            beatmap_id = score.beatmap_id
-            gamemode = score.gamemode
-
-            score.delete()
-            fetch_scores(user_id, [beatmap_id], gamemode)
+            fetch_scores(stats.user_id, beatmap_ids, gamemode)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -559,13 +559,11 @@ class Score(models.Model):
         score.count_100 = self.count_100
         score.count_50 = self.count_50
         score.count_miss = 0
-        # TODO: update to handle lazer statistics
-        score.statistics = {
-            "great": score.count_300,
-            "ok": score.count_100,
-            "meh": score.count_50,
-            "miss": score.count_miss,
-        }
+        score.statistics = self.statistics.copy()
+        score.statistics["great"] = score.count_300
+        score.statistics["ok"] = score.count_100
+        score.statistics["meh"] = score.count_50
+        score.statistics["miss"] = score.count_miss
         score.best_combo = self.beatmap.max_combo
         score.perfect = True
 


### PR DESCRIPTION
## Why?

Fully supporting lazer scores is a journey.

## Changes

- Fix json statistics being incorrect for lazer nochoke scores
- Store lazer score value for lazer scores (classic scores still use old classic score value)
- Split user stats and membership recalc out of diffcalc recalc
- Skip expensive (unused) queries for membership recalc