### PR TITLE
Switch to object based json mods format

### DIFF
--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 from common.osu.enums import Gamemode
-from common.osu.utils import get_json_mods
+from common.osu.utils import get_json_array_mods
 
 # TODO: lazy load this instead of doing at import
 difficalcy_osu_info = httpx.get(f"{settings.DIFFICALCY_OSU_URL}/api/info").json()
@@ -143,7 +143,7 @@ class DifficalcyOsuDifficultyCalculator(AbstractDifficalcyDifficultyCalculator):
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_mods(
+                "Mods": get_json_array_mods(
                     score.mods if score.mods is not None else 0, score.is_stable
                 ),
                 "Combo": score.combo,
@@ -178,7 +178,7 @@ class DifficalcyTaikoDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_mods(
+                "Mods": get_json_array_mods(
                     score.mods if score.mods is not None else 0, score.is_stable
                 ),
                 "Combo": score.combo,
@@ -210,7 +210,7 @@ class DifficalcyCatchDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_mods(
+                "Mods": get_json_array_mods(
                     score.mods if score.mods is not None else 0, score.is_stable
                 ),
                 "Combo": score.combo,
@@ -243,7 +243,7 @@ class DifficalcyManiaDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_mods(
+                "Mods": get_json_array_mods(
                     score.mods if score.mods is not None else 0, score.is_stable
                 ),
                 "Combo": score.combo,
@@ -280,7 +280,7 @@ class DifficalcyPerformancePlusDifficultyCalculator(
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_mods(
+                "Mods": get_json_array_mods(
                     score.mods if score.mods is not None else 0, score.is_stable
                 ),
                 "Combo": score.combo,

--- a/common/osu/osuapi.py
+++ b/common/osu/osuapi.py
@@ -10,7 +10,7 @@ from django.utils.module_loading import import_string
 from ossapi import Beatmap, GameMode, Ossapi, Score, ScoreType, User, UserLookupKey
 
 from common.osu.enums import BeatmapStatus, Gamemode
-from common.osu.utils import get_bitwise_mods, get_json_mods
+from common.osu.utils import get_bitwise_mods, get_json_array_mods
 
 
 class MalformedResponseError(Exception):
@@ -386,7 +386,7 @@ class ScoreData(NamedTuple):
                 else int(data["beatmap_id"])
             ),
             mods=int(data["enabled_mods"]),
-            mods_json=get_json_mods(int(data["enabled_mods"]), is_stable),
+            mods_json=get_json_array_mods(int(data["enabled_mods"]), is_stable),
             is_stable=is_stable,
             score=int(data["score"]),
             best_combo=int(data["maxcombo"]),

--- a/common/osu/stubdata/osuapi/scores.json
+++ b/common/osu/stubdata/osuapi/scores.json
@@ -5,17 +5,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 72,
-                    "mods_json": [
-                        {
-                            "acronym": "HD"
-                        },
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "HD": {},
+                        "DT": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 3502092,
                     "best_combo": 404,
@@ -36,14 +30,10 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1024,
-                    "mods_json": [
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 2475834,
                     "best_combo": 342,
@@ -65,17 +55,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 66,
-                    "mods_json": [
-                        {
-                            "acronym": "EZ"
-                        },
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "EZ": {},
+                        "DT": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 1718512,
                     "best_combo": 404,
@@ -96,14 +80,10 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 2,
-                    "mods_json": [
-                        {
-                            "acronym": "EZ"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "EZ": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 1602032,
                     "best_combo": 404,
@@ -124,20 +104,12 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 74,
-                    "mods_json": [
-                        {
-                            "acronym": "EZ"
-                        },
-                        {
-                            "acronym": "HD"
-                        },
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "EZ": {},
+                        "HD": {},
+                        "DT": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 1078214,
                     "best_combo": 311,
@@ -159,17 +131,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1088,
-                    "mods_json": [
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "DT": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 1060393,
                     "best_combo": 180,
@@ -192,17 +158,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1032,
-                    "mods_json": [
-                        {
-                            "acronym": "HD"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "HD": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 870281,
                     "best_combo": 119,
@@ -224,17 +184,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1600,
-                    "mods_json": [
-                        {
-                            "acronym": "NC"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "NC": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 681752,
                     "best_combo": 128,
@@ -257,20 +211,12 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1089,
-                    "mods_json": [
-                        {
-                            "acronym": "NF"
-                        },
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "NF": {},
+                        "DT": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 334024,
                     "best_combo": 103,
@@ -293,17 +239,11 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1026,
-                    "mods_json": [
-                        {
-                            "acronym": "EZ"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "EZ": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 302882,
                     "best_combo": 94,
@@ -326,23 +266,13 @@
                 {
                     "beatmap_id": 362949,
                     "mods": 1097,
-                    "mods_json": [
-                        {
-                            "acronym": "NF"
-                        },
-                        {
-                            "acronym": "HD"
-                        },
-                        {
-                            "acronym": "DT"
-                        },
-                        {
-                            "acronym": "FL"
-                        },
-                        {
-                            "acronym": "CL"
-                        }
-                    ],
+                    "mods_json": {
+                        "NF": {},
+                        "HD": {},
+                        "DT": {},
+                        "FL": {},
+                        "CL": {}
+                    },
                     "is_stable": true,
                     "score": 214157,
                     "best_combo": 52,

--- a/common/osu/stubdata/osuapi/user_best.json
+++ b/common/osu/stubdata/osuapi/user_best.json
@@ -4,20 +4,12 @@
             {
                 "beatmap_id": 307618,
                 "mods": 104,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "SD"
-                    },
-                    {
-                        "acronym": "DT"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "SD": {},
+                    "DT": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 137805806,
                 "best_combo": 2757,
@@ -38,20 +30,12 @@
             {
                 "beatmap_id": 264364,
                 "mods": 104,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "SD"
-                    },
-                    {
-                        "acronym": "DT"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "SD": {},
+                    "DT": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 4543964,
                 "best_combo": 448,
@@ -72,20 +56,12 @@
             {
                 "beatmap_id": 323769,
                 "mods": 104,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "SD"
-                    },
-                    {
-                        "acronym": "DT"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "SD": {},
+                    "DT": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 10001459,
                 "best_combo": 645,
@@ -137,11 +113,9 @@
             {
                 "beatmap_id": 1386221,
                 "mods": 0,
-                "mods_json": [
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 883194,
                 "best_combo": 268,

--- a/common/osu/stubdata/osuapi/user_recent.json
+++ b/common/osu/stubdata/osuapi/user_recent.json
@@ -4,14 +4,10 @@
             {
                 "beatmap_id": 209276,
                 "mods": 8,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 1881030,
                 "best_combo": 294,
@@ -33,14 +29,10 @@
             {
                 "beatmap_id": 1117451,
                 "mods": 8,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 2572332,
                 "best_combo": 174,
@@ -63,17 +55,11 @@
             {
                 "beatmap_id": 638017,
                 "mods": 24,
-                "mods_json": [
-                    {
-                        "acronym": "HD"
-                    },
-                    {
-                        "acronym": "HR"
-                    },
-                    {
-                        "acronym": "CL"
-                    }
-                ],
+                "mods_json": {
+                    "HD": {},
+                    "HR": {},
+                    "CL": {}
+                },
                 "is_stable": true,
                 "score": 9393700,
                 "best_combo": 707,

--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -9,6 +9,7 @@ from common.osu.utils import (
     get_gamemode_from_gamemode_string,
     get_gamemode_string_from_gamemode,
     get_json_array_mods,
+    get_json_object_mods,
     get_length,
     get_mods_string,
     get_od,
@@ -167,6 +168,32 @@ def test_get_json_array_mods():
         {"acronym": "FL"},
         {"acronym": "PF"},
     ]
+
+
+def test_get_json_object_mods():
+    assert get_json_object_mods(
+        Mods.HIDDEN + Mods.DOUBLETIME + Mods.SUDDEN_DEATH, True
+    ) == {
+        "HD": {},
+        "SD": {},
+        "DT": {},
+        "CL": {},
+    }
+
+    assert get_json_object_mods(
+        Mods.HARDROCK
+        + Mods.FLASHLIGHT
+        + Mods.SUDDEN_DEATH
+        + Mods.PERFECT
+        + Mods.DOUBLETIME
+        + Mods.NIGHTCORE,
+        False,
+    ) == {
+        "HR": {},
+        "NC": {},
+        "FL": {},
+        "PF": {},
+    }
 
 
 def test_get_bitwise_mods():

--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -8,7 +8,7 @@ from common.osu.utils import (
     get_cs,
     get_gamemode_from_gamemode_string,
     get_gamemode_string_from_gamemode,
-    get_json_mods,
+    get_json_array_mods,
     get_length,
     get_mods_string,
     get_od,
@@ -143,15 +143,17 @@ def test_get_mods_string():
     )
 
 
-def test_get_json_mods():
-    assert get_json_mods(Mods.HIDDEN + Mods.SUDDEN_DEATH + Mods.DOUBLETIME, True) == [
+def test_get_json_array_mods():
+    assert get_json_array_mods(
+        Mods.HIDDEN + Mods.SUDDEN_DEATH + Mods.DOUBLETIME, True
+    ) == [
         {"acronym": "HD"},
         {"acronym": "SD"},
         {"acronym": "DT"},
         {"acronym": "CL"},
     ]
 
-    assert get_json_mods(
+    assert get_json_array_mods(
         Mods.HARDROCK
         + Mods.FLASHLIGHT
         + Mods.SUDDEN_DEATH

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -275,6 +275,20 @@ def get_json_array_mods(mods: int, add_classic: bool) -> list[dict]:
     return json_mods
 
 
+def get_json_object_mods(mods: int, add_classic: bool) -> dict:
+    mods_dict = {mod_acronyms[mod]: {} for mod in mod_acronyms if mod & mods != 0}
+
+    if Mods.NIGHTCORE & mods:
+        mods_dict.pop("DT")
+    if Mods.PERFECT & mods:
+        mods_dict.pop("SD")
+
+    if add_classic:
+        mods_dict["CL"] = {}
+
+    return mods_dict
+
+
 def get_bitwise_mods(acronyms: list[str]) -> int:
     bitwise_mods = 0
     for acronym in acronyms:

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -259,7 +259,7 @@ def get_mods_string(mods: int):
     return ",".join(mod_strings)
 
 
-def get_json_mods(mods: int, add_classic: bool) -> list[dict]:
+def get_json_array_mods(mods: int, add_classic: bool) -> list[dict]:
     json_mods = [
         {"acronym": mod_acronyms[mod]} for mod in mod_acronyms if mod & mods != 0
     ]

--- a/conftest.py
+++ b/conftest.py
@@ -123,12 +123,7 @@ def score(user_stats: UserStats, beatmap: Beatmap):
         best_combo=2757,
         perfect=False,
         mods=Mods.DOUBLETIME + Mods.HIDDEN + Mods.SUDDEN_DEATH,
-        mods_json=[
-            {"acronym": "DT"},
-            {"acronym": "HD"},
-            {"acronym": "SD"},
-            {"acronym": "CL"},
-        ],
+        mods_json={"DT": {}, "HD": {}, "SD": {}, "CL": {}},
         is_stable=True,
         rank="SH",
         date=datetime(2023, 1, 1, tzinfo=timezone.utc),

--- a/profiles/management/commands/backfilljsonmods.py
+++ b/profiles/management/commands/backfilljsonmods.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.core.paginator import Paginator
 from tqdm import tqdm
 
-from common.osu.utils import get_json_array_mods
+from common.osu.utils import get_json_object_mods
 from profiles.models import Score
 
 
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         with tqdm(total=scores.count(), smoothing=0) as pbar:
             for page in paginator:
                 for score in page:
-                    score.mods_json = get_json_array_mods(score.mods, score.is_stable)
+                    score.mods_json = get_json_object_mods(score.mods, score.is_stable)
                     pbar.update()
 
                 Score.objects.bulk_update(page, ["mods_json"])

--- a/profiles/management/commands/backfilljsonmods.py
+++ b/profiles/management/commands/backfilljsonmods.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.core.paginator import Paginator
 from tqdm import tqdm
 
-from common.osu.utils import get_json_mods
+from common.osu.utils import get_json_array_mods
 from profiles.models import Score
 
 
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         with tqdm(total=scores.count(), smoothing=0) as pbar:
             for page in paginator:
                 for score in page:
-                    score.mods_json = get_json_mods(score.mods, score.is_stable)
+                    score.mods_json = get_json_array_mods(score.mods, score.is_stable)
                     pbar.update()
 
                 Score.objects.bulk_update(page, ["mods_json"])


### PR DESCRIPTION
## Why?

Object based json mods are more compact, make more sense as keys are unique, and have native ORM support, so it's a more natural fit for osuchan.

## Changes

- Add new `get_json_object_mods()` util
- Update to use new object based json mods format