### PR TITLE
Fix mod settings being considered ranked

### DIFF
--- a/common/osu/stubdata/osuapi/user_best.json
+++ b/common/osu/stubdata/osuapi/user_best.json
@@ -81,7 +81,7 @@
             {
                 "beatmap_id": 422328,
                 "mods": 0,
-                "mods_json": [],
+                "mods_json": {},
                 "is_stable": false,
                 "score": 548961,
                 "best_combo": 127,

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -339,6 +339,8 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
 
         if score.mods & Mods.UNRANKED != 0:
             continue
+        if any(settings != {} for settings in score.mods_json.values()):
+            continue
 
         # Update foreign keys
         beatmap_id = score_data.beatmap_id


### PR DESCRIPTION
## Why?

Mod settings aren't ranked yet, so we'll ignore these scores for now.
I think CL on lazer also isn't ranked, need to check and fix later.

## Changes

- Ignore scores with mod settings