### PR TITLE
Fix lazer CL scores being ranked

### DIFF
--- a/common/osu/stubdata/osuapi/user_recent.json
+++ b/common/osu/stubdata/osuapi/user_recent.json
@@ -108,6 +108,34 @@
                 "perfect": false,
                 "rank": "A",
                 "date": "2024-12-14T11:41:59+00:00"
+            },
+            {
+                "beatmap_id": 386728,
+                "mods": 0,
+                "mods_json": {
+                    "CL": {}
+                },
+                "is_stable": false,
+                "score": 527683,
+                "best_combo": 269,
+                "count_300": 1276,
+                "count_100": 69,
+                "count_50": 0,
+                "count_miss": 20,
+                "count_katu": 0,
+                "count_geki": 0,
+                "statistics": {
+                    "ok": 69,
+                    "miss": 20,
+                    "great": 1276,
+                    "ignore_hit": 332,
+                    "ignore_miss": 9,
+                    "large_tick_hit": 40,
+                    "slider_tail_hit": 327
+                },
+                "perfect": false,
+                "rank": "A",
+                "date": "2024-12-14T11:42:00+00:00"
             }
         ],
         "1": [],

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -339,7 +339,13 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
 
         if score.mods & Mods.UNRANKED != 0:
             continue
+
+        # Mod settings are currently unranked
         if any(settings != {} for settings in score.mods_json.values()):
+            continue
+
+        # Lazer scores with CL are currently unranked
+        if not score.is_stable and "CL" in score.mods_json:
             continue
 
         # Update foreign keys


### PR DESCRIPTION
## Why?

Lazer CL scores are not yet ranked (there are slight inaccuracies with lazer CL vs stable?).

## Changes

- Ignore lazer scores with CL
- Add lazer CL score to stub data to test