### PR TITLE
Use json mods

### DIFF
--- a/common/osu/difficultycalculator.py
+++ b/common/osu/difficultycalculator.py
@@ -34,8 +34,7 @@ DIFFICALCY_PERFORMANCEPLUS_VERSION = difficalcy_performanceplus_info[
 
 class Score(NamedTuple):
     beatmap_id: str
-    mods: int | None = None
-    is_stable: bool = True
+    mods: dict[str, dict] = {}
     statistics: dict[str, int] = {}
     combo: int | None = None
 
@@ -108,6 +107,12 @@ class AbstractDifficalcyDifficultyCalculator(AbstractDifficultyCalculator):
     def _difficalcy_score_from_score(self, score: Score) -> dict:
         raise NotImplementedError()
 
+    @staticmethod
+    def _get_difficalcy_mods(mods: dict[str, dict]) -> list[dict]:
+        return [
+            {"acronym": mod, "settings": settings} for mod, settings in mods.items()
+        ]
+
     def calculate_scores(self, scores: Iterable[Score]) -> list[Calculation]:
         try:
             response = self.client.post(
@@ -143,9 +148,7 @@ class DifficalcyOsuDifficultyCalculator(AbstractDifficalcyDifficultyCalculator):
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_array_mods(
-                    score.mods if score.mods is not None else 0, score.is_stable
-                ),
+                "Mods": self._get_difficalcy_mods(score.mods),
                 "Combo": score.combo,
                 "Misses": score.statistics.get("miss", 0),
                 "Mehs": score.statistics.get("meh", 0),
@@ -178,9 +181,7 @@ class DifficalcyTaikoDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_array_mods(
-                    score.mods if score.mods is not None else 0, score.is_stable
-                ),
+                "Mods": self._get_difficalcy_mods(score.mods),
                 "Combo": score.combo,
                 "Misses": score.statistics.get("miss", 0),
                 "Oks": score.statistics.get("ok", 0),
@@ -210,9 +211,7 @@ class DifficalcyCatchDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_array_mods(
-                    score.mods if score.mods is not None else 0, score.is_stable
-                ),
+                "Mods": self._get_difficalcy_mods(score.mods),
                 "Combo": score.combo,
                 "Misses": score.statistics.get("miss", 0),
                 "SmallDroplets": score.statistics.get("small_tick_hit", 0),
@@ -243,9 +242,7 @@ class DifficalcyManiaDifficultyCalculator(AbstractDifficalcyDifficultyCalculator
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_array_mods(
-                    score.mods if score.mods is not None else 0, score.is_stable
-                ),
+                "Mods": self._get_difficalcy_mods(score.mods),
                 "Combo": score.combo,
                 "Misses": score.statistics.get("miss", 0),
                 "Mehs": score.statistics.get("meh", 0),
@@ -280,9 +277,7 @@ class DifficalcyPerformancePlusDifficultyCalculator(
             k: v
             for k, v in {
                 "BeatmapId": score.beatmap_id,
-                "Mods": get_json_array_mods(
-                    score.mods if score.mods is not None else 0, score.is_stable
-                ),
+                "Mods": self._get_difficalcy_mods(score.mods),
                 "Combo": score.combo,
                 "Misses": score.statistics.get("miss", 0),
                 "Mehs": score.statistics.get("meh", 0),

--- a/common/osu/enums.py
+++ b/common/osu/enums.py
@@ -1,6 +1,6 @@
 # osu! related enums
 
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 
 # Mods
 # https://github.com/ppy/osu-api/wiki#mods
@@ -63,6 +63,41 @@ class Mods(IntEnum):
     UNRANKED = (
         RELAX | AUTO | AUTOPILOT | KEY_1 | KEY_2 | KEY_3 | KEY_COOP | RANDOM | SCORE_V2
     )
+
+
+class NewMods(StrEnum):
+    NOFAIL = "NF"
+    EASY = "EZ"
+    TOUCH_DEVICE = "TD"
+    HIDDEN = "HD"
+    HARDROCK = "HR"
+    SUDDEN_DEATH = "SD"
+    DOUBLETIME = "DT"
+    RELAX = "RX"
+    HALFTIME = "HT"
+    NIGHTCORE = "NC"
+    FLASHLIGHT = "FL"
+    AUTO = "AUTO"
+    SPUN_OUT = "SO"
+    AUTOPILOT = "AP"
+    PERFECT = "PF"
+    KEY_4 = "4K"
+    KEY_5 = "5K"
+    KEY_6 = "6K"
+    KEY_7 = "7K"
+    KEY_8 = "8K"
+    FADE_IN = "FI"
+    RANDOM = "RN"
+    CINEMA = "CN"
+    TARGET_PRACTICE = "TP"
+    KEY_9 = "9K"
+    KEY_COOP = "COOP"
+    KEY_1 = "1K"
+    KEY_2 = "2K"
+    KEY_3 = "3K"
+    SCORE_V2 = "V2"
+    MIRROR = "MI"
+    CLASSIC = "CL"
 
 
 # Gamemodes

--- a/common/osu/test_difficultycalculator.py
+++ b/common/osu/test_difficultycalculator.py
@@ -10,13 +10,15 @@ from common.osu.difficultycalculator import (
     DifficalcyTaikoDifficultyCalculator,
     Score,
 )
-from common.osu.enums import Mods
+from common.osu.enums import NewMods
 
 
 class TestDifficalcyDifficultyCalculator:
     def test_context_manager(self):
         with DifficalcyOsuDifficultyCalculator() as calc:
-            assert calc.calculate_scores([Score("307618")]) == [
+            assert calc.calculate_scores(
+                [Score("307618", mods={NewMods.CLASSIC: {}})]
+            ) == [
                 Calculation(
                     difficulty_values={
                         "aim": 2.095341891859337,
@@ -44,7 +46,7 @@ class TestDifficalcyDifficultyCalculator:
         scores = [
             Score(
                 "307618",
-                mods=int(Mods.DOUBLETIME + Mods.HIDDEN),
+                mods={NewMods.DOUBLETIME: {}, NewMods.HIDDEN: {}, NewMods.CLASSIC: {}},
                 statistics={
                     "ok": 14,
                     "meh": 1,
@@ -54,7 +56,12 @@ class TestDifficalcyDifficultyCalculator:
             ),
             Score(
                 "307618",
-                mods=int(Mods.DOUBLETIME + Mods.HIDDEN + Mods.HARDROCK),
+                mods={
+                    NewMods.DOUBLETIME: {},
+                    NewMods.HIDDEN: {},
+                    NewMods.HARDROCK: {},
+                    NewMods.CLASSIC: {},
+                },
                 statistics={
                     "ok": 14,
                     "meh": 1,
@@ -64,11 +71,15 @@ class TestDifficalcyDifficultyCalculator:
             ),
             Score(
                 "307618",
-                mods=int(Mods.DOUBLETIME + Mods.HIDDEN + Mods.HARDROCK),
+                mods={
+                    NewMods.DOUBLETIME: {},
+                    NewMods.HIDDEN: {},
+                    NewMods.HARDROCK: {},
+                    NewMods.CLASSIC: {},
+                },
             ),
             Score(
                 "422328",
-                is_stable=False,
                 statistics={
                     "ok": 13,
                     "miss": 14,
@@ -158,7 +169,7 @@ class TestDifficalcyOsuDifficultyCalculator:
         calc = DifficalcyOsuDifficultyCalculator()
         score = Score(
             "307618",
-            mods=int(Mods.DOUBLETIME + Mods.HIDDEN),
+            mods={NewMods.DOUBLETIME: {}, NewMods.HIDDEN: {}, NewMods.CLASSIC: {}},
             statistics={
                 "ok": 14,
                 "meh": 1,
@@ -196,7 +207,7 @@ class TestDifficalcyTaikoDifficultyCalculator:
         calc = DifficalcyTaikoDifficultyCalculator()
         score = Score(
             "2",
-            mods=int(Mods.DOUBLETIME + Mods.HARDROCK),
+            mods={NewMods.DOUBLETIME: {}, NewMods.HARDROCK: {}, NewMods.CLASSIC: {}},
             statistics={
                 "ok": 3,
                 "miss": 5,
@@ -231,7 +242,7 @@ class TestDifficalcyCatchDifficultyCalculator:
         calc = DifficalcyCatchDifficultyCalculator()
         score = Score(
             "3",
-            mods=int(Mods.DOUBLETIME + Mods.HARDROCK),
+            mods={NewMods.DOUBLETIME: {}, NewMods.HARDROCK: {}, NewMods.CLASSIC: {}},
             statistics={
                 "large_tick_hit": 18,
                 "small_tick_hit": 200,
@@ -262,7 +273,7 @@ class TestDifficalcyManiaDifficultyCalculator:
         calc = DifficalcyManiaDifficultyCalculator()
         score = Score(
             "4",
-            mods=int(Mods.DOUBLETIME + Mods.EASY),
+            mods={NewMods.DOUBLETIME: {}, NewMods.EASY: {}, NewMods.CLASSIC: {}},
             statistics={
                 "great": 1,
                 "good": 2,
@@ -301,7 +312,7 @@ class TestDifficalcyPerformancePlusDifficultyCalculator:
         calc = DifficalcyPerformancePlusDifficultyCalculator()
         score = Score(
             "307618",
-            mods=int(Mods.DOUBLETIME + Mods.HIDDEN),
+            mods={NewMods.DOUBLETIME: {}, NewMods.HIDDEN: {}, NewMods.CLASSIC: {}},
             statistics={
                 "ok": 14,
                 "meh": 1,

--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -1,4 +1,4 @@
-from common.osu.enums import Gamemode, Mods
+from common.osu.enums import Gamemode, Mods, NewMods
 from common.osu.utils import (
     calculate_pp_total,
     get_ar,
@@ -13,6 +13,7 @@ from common.osu.utils import (
     get_length,
     get_mods_string,
     get_od,
+    mods_are_ranked,
 )
 
 
@@ -210,3 +211,50 @@ def test_get_bitwise_mods():
         + Mods.DOUBLETIME
         + Mods.NIGHTCORE
     )
+
+def test_mods_are_ranked():
+    assert mods_are_ranked({NewMods.CLASSIC: {}}, True) == True
+    assert mods_are_ranked({}, False) == True
+
+    assert mods_are_ranked({
+        NewMods.HIDDEN: {},
+        NewMods.DOUBLETIME: {},
+        NewMods.SUDDEN_DEATH: {},
+        NewMods.CLASSIC: {}
+    }, True) == True
+
+    assert mods_are_ranked({
+        NewMods.HIDDEN: {},
+        NewMods.DOUBLETIME: {},
+        NewMods.SUDDEN_DEATH: {},
+    }, False) == True
+
+    assert mods_are_ranked({
+        NewMods.HIDDEN: {},
+        NewMods.DOUBLETIME: {},
+        NewMods.SUDDEN_DEATH: {},
+        NewMods.RELAX: {},
+        NewMods.CLASSIC: {}
+    }, True) == False
+
+    assert mods_are_ranked({
+        NewMods.HIDDEN: {},
+        NewMods.DOUBLETIME: {},
+        NewMods.SUDDEN_DEATH: {},
+        NewMods.RELAX: {},
+    }, False) == False
+
+    assert mods_are_ranked({
+        NewMods.CLASSIC: {}
+    }, True) == True
+
+    assert mods_are_ranked({
+        NewMods.CLASSIC: {}
+    }, False) == False
+
+    assert mods_are_ranked({
+        NewMods.DOUBLETIME: {
+            "speed_change": 1.2
+        }
+    }, False) == False
+    

--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -76,53 +76,57 @@ def test_get_accuracy():
 
 
 def test_get_bpm():
-    assert get_bpm(180, Mods.NONE) == 180
-    assert get_bpm(180, Mods.DOUBLETIME) == 270
-    assert get_bpm(180, Mods.DOUBLETIME + Mods.NIGHTCORE) == 270
-    assert get_bpm(180, Mods.HALFTIME) == 135
+    assert get_bpm(180, {}) == 180
+    assert get_bpm(180, {NewMods.DOUBLETIME: {}}) == 270
+    assert get_bpm(180, {NewMods.DOUBLETIME: {}, NewMods.NIGHTCORE: {}}) == 270
+    assert get_bpm(180, {NewMods.HALFTIME: {}}) == 135
 
 
 def test_get_length():
-    assert get_length(90, Mods.NONE) == 90
-    assert get_length(90, Mods.DOUBLETIME) == 60
-    assert get_length(90, Mods.DOUBLETIME + Mods.NIGHTCORE) == 60
-    assert get_length(90, Mods.HALFTIME) == 120
+    assert get_length(90, {}) == 90
+    assert get_length(90, {NewMods.DOUBLETIME: {}}) == 60
+    assert get_length(90, {NewMods.DOUBLETIME: {}, NewMods.NIGHTCORE: {}}) == 60
+    assert get_length(90, {NewMods.HALFTIME: {}}) == 120
 
 
 def test_get_cs():
-    assert get_cs(4, Mods.NONE, Gamemode.STANDARD) == 4
-    assert get_cs(4, Mods.HARDROCK, Gamemode.STANDARD) == 5.2
-    assert get_cs(4, Mods.EASY, Gamemode.STANDARD) == 2
-    assert get_cs(4, Mods.KEY_1, Gamemode.MANIA) == 1
-    assert get_cs(4, Mods.KEY_2, Gamemode.MANIA) == 2
-    assert get_cs(4, Mods.KEY_3, Gamemode.MANIA) == 3
-    assert get_cs(4, Mods.KEY_4, Gamemode.MANIA) == 4
-    assert get_cs(4, Mods.KEY_5, Gamemode.MANIA) == 5
-    assert get_cs(4, Mods.KEY_6, Gamemode.MANIA) == 6
-    assert get_cs(4, Mods.KEY_7, Gamemode.MANIA) == 7
-    assert get_cs(4, Mods.KEY_8, Gamemode.MANIA) == 8
-    assert get_cs(4, Mods.KEY_9, Gamemode.MANIA) == 9
-    assert get_cs(4, Mods.KEY_COOP, Gamemode.MANIA) == 4
+    assert get_cs(4, {}, Gamemode.STANDARD) == 4
+    assert get_cs(4, {NewMods.HARDROCK: {}}, Gamemode.STANDARD) == 5.2
+    assert get_cs(4, {NewMods.EASY: {}}, Gamemode.STANDARD) == 2
+    assert get_cs(4, {NewMods.KEY_1: {}}, Gamemode.MANIA) == 1
+    assert get_cs(4, {NewMods.KEY_2: {}}, Gamemode.MANIA) == 2
+    assert get_cs(4, {NewMods.KEY_3: {}}, Gamemode.MANIA) == 3
+    assert get_cs(4, {NewMods.KEY_4: {}}, Gamemode.MANIA) == 4
+    assert get_cs(4, {NewMods.KEY_5: {}}, Gamemode.MANIA) == 5
+    assert get_cs(4, {NewMods.KEY_6: {}}, Gamemode.MANIA) == 6
+    assert get_cs(4, {NewMods.KEY_7: {}}, Gamemode.MANIA) == 7
+    assert get_cs(4, {NewMods.KEY_8: {}}, Gamemode.MANIA) == 8
+    assert get_cs(4, {NewMods.KEY_9: {}}, Gamemode.MANIA) == 9
+    assert get_cs(4, {NewMods.KEY_COOP: {}}, Gamemode.MANIA) == 4
 
 
 def test_get_ar():
-    assert get_ar(9, Mods.NONE) == 9
-    assert get_ar(9, Mods.DOUBLETIME) == 10.333333333333334
-    assert get_ar(9, Mods.DOUBLETIME + Mods.NIGHTCORE) == 10.333333333333334
-    assert get_ar(9, Mods.HARDROCK) == 10
+    assert get_ar(9, {}) == 9
+    assert get_ar(9, {NewMods.DOUBLETIME: {}}) == 10.333333333333334
+    assert (
+        get_ar(9, {NewMods.DOUBLETIME: {}, NewMods.NIGHTCORE: {}}) == 10.333333333333334
+    )
+    assert get_ar(9, {NewMods.HARDROCK: {}}) == 10
 
-    assert get_ar(5, Mods.HALFTIME) == 1.6666666666666667
-    assert get_ar(5, Mods.EASY) == 2.5
+    assert get_ar(5, {NewMods.HALFTIME: {}}) == 1.6666666666666667
+    assert get_ar(5, {NewMods.EASY: {}}) == 2.5
 
 
 def test_get_od():
-    assert get_od(9, Mods.NONE) == 9
-    assert get_od(9, Mods.DOUBLETIME) == 10.416666666666666
-    assert get_od(9, Mods.DOUBLETIME + Mods.NIGHTCORE) == 10.416666666666666
-    assert get_od(9, Mods.HARDROCK) == 10
+    assert get_od(9, {}) == 9
+    assert get_od(9, {NewMods.DOUBLETIME: {}}) == 10.416666666666666
+    assert (
+        get_od(9, {NewMods.DOUBLETIME: {}, NewMods.NIGHTCORE: {}}) == 10.416666666666666
+    )
+    assert get_od(9, {NewMods.HARDROCK: {}}) == 10
 
-    assert get_od(5, Mods.HALFTIME) == 2.25
-    assert get_od(5, Mods.EASY) == 2.5
+    assert get_od(5, {NewMods.HALFTIME: {}}) == 2.25
+    assert get_od(5, {NewMods.EASY: {}}) == 2.5
 
 
 def test_get_gamemode_from_gamemode_string():
@@ -212,49 +216,65 @@ def test_get_bitwise_mods():
         + Mods.NIGHTCORE
     )
 
+
 def test_mods_are_ranked():
     assert mods_are_ranked({NewMods.CLASSIC: {}}, True) == True
     assert mods_are_ranked({}, False) == True
 
-    assert mods_are_ranked({
-        NewMods.HIDDEN: {},
-        NewMods.DOUBLETIME: {},
-        NewMods.SUDDEN_DEATH: {},
-        NewMods.CLASSIC: {}
-    }, True) == True
+    assert (
+        mods_are_ranked(
+            {
+                NewMods.HIDDEN: {},
+                NewMods.DOUBLETIME: {},
+                NewMods.SUDDEN_DEATH: {},
+                NewMods.CLASSIC: {},
+            },
+            True,
+        )
+        == True
+    )
 
-    assert mods_are_ranked({
-        NewMods.HIDDEN: {},
-        NewMods.DOUBLETIME: {},
-        NewMods.SUDDEN_DEATH: {},
-    }, False) == True
+    assert (
+        mods_are_ranked(
+            {
+                NewMods.HIDDEN: {},
+                NewMods.DOUBLETIME: {},
+                NewMods.SUDDEN_DEATH: {},
+            },
+            False,
+        )
+        == True
+    )
 
-    assert mods_are_ranked({
-        NewMods.HIDDEN: {},
-        NewMods.DOUBLETIME: {},
-        NewMods.SUDDEN_DEATH: {},
-        NewMods.RELAX: {},
-        NewMods.CLASSIC: {}
-    }, True) == False
+    assert (
+        mods_are_ranked(
+            {
+                NewMods.HIDDEN: {},
+                NewMods.DOUBLETIME: {},
+                NewMods.SUDDEN_DEATH: {},
+                NewMods.RELAX: {},
+                NewMods.CLASSIC: {},
+            },
+            True,
+        )
+        == False
+    )
 
-    assert mods_are_ranked({
-        NewMods.HIDDEN: {},
-        NewMods.DOUBLETIME: {},
-        NewMods.SUDDEN_DEATH: {},
-        NewMods.RELAX: {},
-    }, False) == False
+    assert (
+        mods_are_ranked(
+            {
+                NewMods.HIDDEN: {},
+                NewMods.DOUBLETIME: {},
+                NewMods.SUDDEN_DEATH: {},
+                NewMods.RELAX: {},
+            },
+            False,
+        )
+        == False
+    )
 
-    assert mods_are_ranked({
-        NewMods.CLASSIC: {}
-    }, True) == True
+    assert mods_are_ranked({NewMods.CLASSIC: {}}, True) == True
 
-    assert mods_are_ranked({
-        NewMods.CLASSIC: {}
-    }, False) == False
+    assert mods_are_ranked({NewMods.CLASSIC: {}}, False) == False
 
-    assert mods_are_ranked({
-        NewMods.DOUBLETIME: {
-            "speed_change": 1.2
-        }
-    }, False) == False
-    
+    assert mods_are_ranked({NewMods.DOUBLETIME: {"speed_change": 1.2}}, False) == False

--- a/common/osu/test_utils.py
+++ b/common/osu/test_utils.py
@@ -12,6 +12,7 @@ from common.osu.utils import (
     get_json_object_mods,
     get_length,
     get_mods_string,
+    get_mods_string_from_json_mods,
     get_od,
     mods_are_ranked,
 )
@@ -146,6 +147,28 @@ def test_get_gamemode_string_from_gamemode():
 def test_get_mods_string():
     assert (
         get_mods_string(Mods.HIDDEN + Mods.DOUBLETIME + Mods.SUDDEN_DEATH) == "HD,SD,DT"
+    )
+
+
+def test_get_mods_string_from_json_mods():
+    assert get_mods_string_from_json_mods({}) == ""
+    assert get_mods_string_from_json_mods({NewMods.CLASSIC: {}}) == "CL"
+    assert (
+        get_mods_string_from_json_mods(
+            {NewMods.HIDDEN: {}, NewMods.DOUBLETIME: {}, NewMods.SUDDEN_DEATH: {}}
+        )
+        == "HD,SD,DT"
+    )
+    assert (
+        get_mods_string_from_json_mods(
+            {
+                NewMods.HARDROCK: {},
+                NewMods.NIGHTCORE: {},
+                NewMods.FLASHLIGHT: {},
+                NewMods.PERFECT: {},
+            }
+        )
+        == "HR,NC,FL,PF"
     )
 
 

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -253,6 +253,10 @@ def get_mods_string(mods: int):
     return ",".join(mod_strings)
 
 
+def get_mods_string_from_json_mods(mods: dict):
+    return ",".join(mod for mod in NewMods if mod in mods)
+
+
 def get_json_array_mods(mods: int, add_classic: bool) -> list[dict]:
     json_mods = [
         {"acronym": mod_acronyms[mod]} for mod in mod_acronyms if mod & mods != 0

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -1,6 +1,6 @@
 # osu! related utils
 
-from common.osu.enums import Gamemode, Mods
+from common.osu.enums import Gamemode, Mods, NewMods
 
 
 def calculate_pp_total(sorted_pps):
@@ -303,3 +303,25 @@ def get_bitwise_mods(acronyms: list[str]) -> int:
         bitwise_mods |= Mods.SUDDEN_DEATH
 
     return bitwise_mods
+
+
+unranked_mods = [
+    NewMods.RELAX,
+    NewMods.AUTO,
+    NewMods.AUTOPILOT,
+    NewMods.KEY_1,
+    NewMods.KEY_2,
+    NewMods.KEY_3,
+    NewMods.KEY_COOP,
+    NewMods.RANDOM,
+    NewMods.SCORE_V2
+]
+
+def mods_are_ranked(mods: dict, is_stable: bool) -> bool:
+    if any(mod in unranked_mods for mod in mods):
+        return False
+    if any(settings != {} for settings in mods.values()):
+        return False
+    if not is_stable and NewMods.CLASSIC in mods:
+        return False
+    return True

--- a/common/osu/utils.py
+++ b/common/osu/utils.py
@@ -60,71 +60,67 @@ def get_classic_accuracy(
         return 0
 
 
-def get_bpm(bpm, mods):
+def get_bpm(bpm: float, mods: dict):
     bpm = float(bpm)
-    mods = int(mods)
-    if mods & Mods.DOUBLETIME:
+    if NewMods.DOUBLETIME in mods:
         return bpm * 1.5
-    elif mods & Mods.HALFTIME:
+    elif NewMods.HALFTIME in mods:
         return bpm * (3 / 4)
     else:
         return bpm
 
 
-def get_length(length, mods):
+def get_length(length: float, mods: dict):
     length = float(length)
-    mods = int(mods)
-    if mods & Mods.DOUBLETIME:
+    if NewMods.DOUBLETIME in mods:
         return length / 1.5
-    elif mods & Mods.HALFTIME:
+    elif NewMods.HALFTIME in mods:
         return length / (3 / 4)
     else:
         return length
 
 
-def get_cs(cs, mods, gamemode):
+def get_cs(cs: float, mods: dict, gamemode: Gamemode):
     cs = float(cs)
-    mods = int(mods)
 
     if gamemode == Gamemode.MANIA:
-        if mods & Mods.KEY_MOD:
-            if mods & Mods.KEY_1:
-                return 1
-            if mods & Mods.KEY_2:
-                return 2
-            if mods & Mods.KEY_3:
-                return 3
-            if mods & Mods.KEY_4:
-                return 4
-            if mods & Mods.KEY_5:
-                return 5
-            if mods & Mods.KEY_6:
-                return 6
-            if mods & Mods.KEY_7:
-                return 7
-            if mods & Mods.KEY_8:
-                return 8
-            if mods & Mods.KEY_9:
-                return 9
+        if NewMods.KEY_1 in mods:
+            return 1
+        if NewMods.KEY_2 in mods:
+            return 2
+        if NewMods.KEY_3 in mods:
+            return 3
+        if NewMods.KEY_4 in mods:
+            return 4
+        if NewMods.KEY_5 in mods:
+            return 5
+        if NewMods.KEY_6 in mods:
+            return 6
+        if NewMods.KEY_7 in mods:
+            return 7
+        if NewMods.KEY_8 in mods:
+            return 8
+        if NewMods.KEY_9 in mods:
+            return 9
         return cs
 
-    if mods & Mods.HARDROCK:
+    if NewMods.HARDROCK in mods:
         cs *= 1.3
-    if mods & Mods.EASY:
+    if NewMods.EASY in mods:
         cs *= 0.5
 
     return cs
 
 
-def get_ar(ar, mods):
-    def ar_to_ms(ar):  # convert ar to ms
+def get_ar(ar: float, mods: dict):
+    def ar_to_ms(ar: float):  # convert ar to ms
         if ar <= 5:
             ms = -120 * ar + 1800
         else:
             ms = -150 * ar + 1950
         return ms
 
-    def ms_to_ar(ms):  # convert ms to ar
+    def ms_to_ar(ms: float):  # convert ms to ar
         if ms >= 1200:
             ar = (ms - 1800) / -120
         else:
@@ -132,50 +128,48 @@ def get_ar(ar, mods):
         return ar
 
     ar = float(ar)
-    mods = int(mods)
 
-    if mods & Mods.HARDROCK:
+    if NewMods.HARDROCK in mods:
         ar *= 1.4
-    if mods & Mods.EASY:
+    if NewMods.EASY in mods:
         ar *= 0.5
 
     if ar > 10:
         ar = 10
 
-    if mods & Mods.DOUBLETIME:
+    if NewMods.DOUBLETIME in mods:
         ms = ar_to_ms(ar) / 1.5
         ar = ms_to_ar(ms)
-    if mods & Mods.HALFTIME:
+    if NewMods.HALFTIME in mods:
         ms = ar_to_ms(ar) / (3 / 4)
         ar = ms_to_ar(ms)
 
     return ar
 
 
-def get_od(od, mods):
-    def od_to_ms(od):  # convert od to ms
+def get_od(od: float, mods: dict):
+    def od_to_ms(od: float):  # convert od to ms
         ms = -6 * od + 79.5
         return ms
 
-    def ms_to_od(ms):  # convert ms to od
+    def ms_to_od(ms: float):  # convert ms to od
         od = (ms - 79.5) / -6
         return od
 
     od = float(od)
-    mods = int(mods)
 
-    if mods & Mods.HARDROCK:
+    if NewMods.HARDROCK in mods:
         od *= 1.4
-    elif mods & Mods.EASY:
+    elif NewMods.EASY in mods:
         od *= 0.5
 
     if od > 10:
         od = 10
 
-    if mods & Mods.DOUBLETIME:
+    if NewMods.DOUBLETIME in mods:
         ms = od_to_ms(od) / 1.5
         od = ms_to_od(ms)
-    if mods & Mods.HALFTIME:
+    if NewMods.HALFTIME in mods:
         ms = od_to_ms(od) / (3 / 4)
         od = ms_to_od(ms)
 
@@ -314,8 +308,9 @@ unranked_mods = [
     NewMods.KEY_3,
     NewMods.KEY_COOP,
     NewMods.RANDOM,
-    NewMods.SCORE_V2
+    NewMods.SCORE_V2,
 ]
+
 
 def mods_are_ranked(mods: dict, is_stable: bool) -> bool:
     if any(mod in unranked_mods for mod in mods):

--- a/leaderboards/tasks.py
+++ b/leaderboards/tasks.py
@@ -6,7 +6,10 @@ from django.db import transaction
 
 from common.discord_webhook_sender import DiscordWebhookSender
 from common.osu.enums import Gamemode, Mods
-from common.osu.utils import get_gamemode_string_from_gamemode, get_mods_string
+from common.osu.utils import (
+    get_gamemode_string_from_gamemode,
+    get_mods_string_from_json_mods,
+)
 from leaderboards.enums import LeaderboardAccessType
 from leaderboards.models import Leaderboard, Membership
 from leaderboards.services import update_membership
@@ -47,7 +50,7 @@ def send_leaderboard_top_score_notification(leaderboard_id: int, score_id: int):
 
     beatmap_details = f"[{score.beatmap}](https://osu.ppy.sh/beatmapsets/{score.beatmap.set_id}#{get_gamemode_string_from_gamemode(score.beatmap.gamemode)}/{score.beatmap.id})"
     if score.mods != Mods.NONE:
-        beatmap_details += f" +{get_mods_string(score.mods)}"
+        beatmap_details += f" +{get_mods_string_from_json_mods(score.mods_json)}"
 
     performance_calculation = score.get_performance_calculation()
     difficulty_total = (

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -153,7 +153,7 @@ class ScoreAdmin(admin.ModelAdmin):
     def mods_display(self, obj: Score):
         if obj.mods == Mods.NONE:
             return None
-        return utils.get_mods_string(obj.mods)
+        return utils.get_mods_string_from_json_mods(obj.mods_json)
 
     @admin.display(description="Accuracy")
     def accuracy_display(self, obj: Score):

--- a/profiles/management/commands/recalculate.py
+++ b/profiles/management/commands/recalculate.py
@@ -11,9 +11,7 @@ from common.osu.difficultycalculator import (
     get_difficulty_calculators_for_gamemode,
 )
 from common.osu.enums import Gamemode
-from leaderboards.models import Membership
-from leaderboards.services import update_membership
-from profiles.models import Beatmap, Score, UserStats
+from profiles.models import Beatmap, Score
 from profiles.services import (
     update_difficulty_calculations,
     update_performance_calculations,

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -337,15 +337,7 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
         score.rank = score_data.rank
         score.date = score_data.date
 
-        if score.mods & Mods.UNRANKED != 0:
-            continue
-
-        # Mod settings are currently unranked
-        if any(settings != {} for settings in score.mods_json.values()):
-            continue
-
-        # Lazer scores with CL are currently unranked
-        if not score.is_stable and "CL" in score.mods_json:
+        if not utils.mods_are_ranked(score.mods_json, score.is_stable):
             continue
 
         # Update foreign keys
@@ -366,14 +358,14 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
             score.statistics,
             gamemode=gamemode,
         )
-        score.bpm = utils.get_bpm(score.beatmap.bpm, score.mods)
-        score.length = utils.get_length(score.beatmap.drain_time, score.mods)
+        score.bpm = utils.get_bpm(score.beatmap.bpm, score.mods_json)
+        score.length = utils.get_length(score.beatmap.drain_time, score.mods_json)
         score.circle_size = utils.get_cs(
-            score.beatmap.circle_size, score.mods, score.gamemode
+            score.beatmap.circle_size, score.mods_json, Gamemode(score.gamemode)
         )
-        score.approach_rate = utils.get_ar(score.beatmap.approach_rate, score.mods)
+        score.approach_rate = utils.get_ar(score.beatmap.approach_rate, score.mods_json)
         score.overall_difficulty = utils.get_od(
-            score.beatmap.overall_difficulty, score.mods
+            score.beatmap.overall_difficulty, score.mods_json
         )
 
         # Process score

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -540,7 +540,7 @@ def calculate_difficulty_values(
     calc_scores = [
         DifficultyCalculatorScore(
             beatmap_id=str(difficulty_calculation.beatmap_id),
-            mods=difficulty_calculation.mods,
+            mods=utils.get_json_object_mods(difficulty_calculation.mods, False),
         )
         for difficulty_calculation in difficulty_calculations
     ]
@@ -586,8 +586,10 @@ def calculate_performance_values(
     calc_scores = [
         DifficultyCalculatorScore(
             beatmap_id=str(performance_calculation.score.beatmap_id),
-            mods=performance_calculation.score.mods,
-            is_stable=performance_calculation.score.is_stable,
+            mods=utils.get_json_object_mods(
+                performance_calculation.score.mods,
+                performance_calculation.score.is_stable,
+            ),
             statistics=performance_calculation.score.statistics,
             combo=performance_calculation.score.best_combo,
         )


### PR DESCRIPTION
## Why?

Need to move all functionality to using the json mods before we can get rid of bitwise mods.

## Changes

- Add `NewMods` enum (will be renamed when bitmods enum is gone)
- Refactor to use json mods wherever possible without db changes