### PR TITLE
Use lazer acc for non-classic scores

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: make checkfixup
 
   checkformatting:

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -581,10 +581,18 @@ class Score(models.Model):
         score.perfect = True
 
         # Calculate new accuracy
-        score.accuracy = utils.get_classic_accuracy(
-            score.statistics,
-            gamemode=gamemode,
-        )
+        if NewMods.CLASSIC in score.mods_json:
+            score.accuracy = utils.get_classic_accuracy(
+                score.statistics,
+                gamemode=gamemode,
+            )
+        else:
+            score.accuracy = utils.get_lazer_accuracy(
+                score.statistics,
+                self.beatmap.hitobject_counts,
+                gamemode=gamemode,
+            )
+
         if score.accuracy == 1:
             if (
                 NewMods.HIDDEN in score.mods_json

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -14,7 +14,7 @@ from common.osu.difficultycalculator import Score as DifficultyCalculatorScore
 from common.osu.difficultycalculator import (
     get_difficulty_calculators_for_gamemode,
 )
-from common.osu.enums import BeatmapStatus, Gamemode, Mods
+from common.osu.enums import BeatmapStatus, Gamemode, Mods, NewMods
 from common.osu.osuapi import OsuApi, ScoreData
 from leaderboards.models import Leaderboard, Membership
 from profiles.enums import ScoreMutation, ScoreResult
@@ -356,10 +356,16 @@ def add_scores_from_data(user_stats: UserStats, score_data_list: list[ScoreData]
 
         # Update convenience fields
         score.gamemode = gamemode
-        score.accuracy = utils.get_classic_accuracy(
-            score.statistics,
-            gamemode=gamemode,
-        )
+        if NewMods.CLASSIC in score.mods_json:
+            score.accuracy = utils.get_classic_accuracy(
+                score.statistics,
+                gamemode=gamemode,
+            )
+        else:
+            score.accuracy = utils.get_lazer_accuracy(
+                score.statistics, score.beatmap.hitobject_counts, gamemode
+            )
+
         score.bpm = utils.get_bpm(score.beatmap.bpm, score.mods_json)
         score.length = utils.get_length(score.beatmap.drain_time, score.mods_json)
         score.circle_size = utils.get_cs(

--- a/profiles/test_services.py
+++ b/profiles/test_services.py
@@ -38,7 +38,7 @@ class TestUserServices:
             ).count()
             == 14  # 7 scores (6 real, 1 nochoke mutation) * 2 calculators
         )
-        assert user_stats.score_style_accuracy == 97.42292425653687
+        assert user_stats.score_style_accuracy == 97.62286161777982
         assert user_stats.score_style_bpm == 201.99989929562193
         assert user_stats.score_style_cs == 4.2766715338147065
         assert user_stats.score_style_ar == 9.749798660314049
@@ -57,7 +57,7 @@ class TestUserServices:
             ).count()
             == 38  # 18 scores (17 real, 2 nochoke mutation) * 2 calculators
         )
-        assert user_stats.score_style_accuracy == 97.45617285336796
+        assert user_stats.score_style_accuracy == 97.61837309857572
         assert user_stats.score_style_bpm == 203.85810981390424
         assert user_stats.score_style_cs == 4.224451249870312
         assert user_stats.score_style_ar == 9.740084852929643

--- a/scripts/checkfixup
+++ b/scripts/checkfixup
@@ -5,6 +5,7 @@ COMMIT_MESSAGES=$(git log --oneline)
 if echo "$COMMIT_MESSAGES" | grep -q "fixup!"; then
     echo "Found fixup commits:"
     echo "$COMMIT_MESSAGES" | grep "fixup!"
+    exit 1
 else
     echo "No fixup commits found."
 fi


### PR DESCRIPTION
## Why?

Lazer scores currently incorrectly use the standard algorithm.

## Changes

- Use new lazer acc function for non-CL scores