### PR TITLE
Add healthcheck to celery service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -62,6 +62,8 @@ services:
   worker:
     build: .
     command: celery --app osuchan worker --loglevel info
+    healthcheck:
+      test: celery --app osuchan inspect ping || exit 1
     env_file:
       - config/active/django.env
     volumes:


### PR DESCRIPTION
## Why?

There's a silent celery worker killer that's shown its head again after years of laying dormant...
I don't know what causes it or how to reproduce it, but if it happens again, I want it to fix itself!

## Changes

- Add docker healthcheck to worker in compose