### PR TITLE
Add prioritised tasks

### DIFF
--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,0 +1,19 @@
+# The celery worker
+
+## Task priorities
+
+As a general guide, here are some uses for different task priorities.
+
+| Priority    | Use                          |
+| ----------- | ---------------------------- |
+| Priority 10 | Time sensitive notifications |
+| Priority 9  |                              |
+| Priority 8  |                              |
+| Priority 7  | Profile updates              |
+| Priority 6  |                              |
+| Priority 5  | Default                      |
+| Priority 4  |                              |
+| Priority 3  | Task dispatching tasks       |
+| Priority 2  |                              |
+| Priority 1  |                              |
+| Priority 0  | Background maintenance tasks |

--- a/leaderboards/tasks.py
+++ b/leaderboards/tasks.py
@@ -18,7 +18,7 @@ from profiles.enums import ScoreResult
 from profiles.models import Score
 
 
-@shared_task
+@shared_task(priority=7)
 @transaction.atomic
 def update_memberships(user_id, gamemode=Gamemode.STANDARD):
     """
@@ -36,7 +36,7 @@ def update_memberships(user_id, gamemode=Gamemode.STANDARD):
     return memberships
 
 
-@shared_task
+@shared_task(priority=10)
 def send_leaderboard_top_score_notification(leaderboard_id: int, score_id: int):
     # passing score_id instead of querying for top score in case it changes before the job is picked up
 
@@ -108,7 +108,7 @@ def send_leaderboard_top_score_notification(leaderboard_id: int, score_id: int):
     )
 
 
-@shared_task
+@shared_task(priority=10)
 def send_leaderboard_top_player_notification(leaderboard_id: int, user_id: int):
     # passing user_id instead of querying for top player in case it changes before the job is picked up
 
@@ -167,7 +167,7 @@ def send_leaderboard_top_player_notification(leaderboard_id: int, user_id: int):
     )
 
 
-@shared_task
+@shared_task(priority=10)
 def send_leaderboard_podium_notification(leaderboard_id: int):
     leaderboard: Leaderboard = Leaderboard.objects.get(id=leaderboard_id)
     if leaderboard.notification_discord_webhook_url == "":

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -6,6 +6,7 @@ import os
 from datetime import timedelta
 
 from celery.schedules import crontab
+from kombu import Exchange, Queue
 from pydantic_settings import BaseSettings
 
 from common.osu.enums import Gamemode
@@ -207,6 +208,20 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 250000  # 250MB TODO: investigate this memory leak
+
+CELERY_TASK_QUEUES = [
+    Queue(
+        "tasks",
+        Exchange("tasks"),
+        routing_key="tasks",
+        queue_arguments={
+            "x-max-priority": 10,
+        },
+    )
+]
+
+CELERY_TASK_DEFAULT_PRIORITY = 5
+CELERY_TASK_DEFAULT_QUEUE = "tasks"
 
 CELERY_BEAT_SCHEDULE = {
     "update-top-global-members-every-day": {

--- a/osuchan/test_celery.py
+++ b/osuchan/test_celery.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, create_autospec, patch
 
 from celery import Task
 
-from osuchan.celery import debug_task, task_failure_handler
+from osuchan.celery import task_failure_handler
 
 
 @patch("osuchan.celery.ErrorReporter.report_error")

--- a/profiles/tasks.py
+++ b/profiles/tasks.py
@@ -13,7 +13,7 @@ from profiles.services import refresh_beatmaps_from_api, refresh_user_from_api
 logger = logging.getLogger(__name__)
 
 
-@shared_task
+@shared_task(priority=1)
 def dispatch_update_all_global_leaderboard_top_members(
     limit: int = 100, cooldown_seconds: int = 300
 ):
@@ -27,7 +27,7 @@ def dispatch_update_all_global_leaderboard_top_members(
             update_user.delay(member["user_id"], leaderboard.gamemode, cooldown_seconds)
 
 
-@shared_task
+@shared_task(priority=3)
 def dispatch_update_community_leaderboard_members(
     leaderboard_id: int, limit: int = 100
 ):
@@ -41,7 +41,7 @@ def dispatch_update_community_leaderboard_members(
         update_user.delay(member["user_id"], leaderboard.gamemode)
 
 
-@shared_task
+@shared_task(priority=7)
 def update_user(
     user_id: int, gamemode: int = Gamemode.STANDARD, cooldown_seconds: int = 300
 ):
@@ -58,7 +58,7 @@ def update_user(
     return user_stats
 
 
-@shared_task
+@shared_task(priority=7)
 def update_user_by_username(username: str, gamemode: int = Gamemode.STANDARD):
     """
     Runs an update for a given user
@@ -73,7 +73,7 @@ def update_user_by_username(username: str, gamemode: int = Gamemode.STANDARD):
     return user_stats
 
 
-@shared_task
+@shared_task(priority=0)
 def update_loved_beatmaps():
     """
     Updates all loved beatmaps, cleaning up outdated data


### PR DESCRIPTION
## Why?

Sometimes we get bogged down with batch player update tasks or similar and notifications or other important tasks are delayed.

## Changes

- Add prioritisation to queue with differing priorities for tasks