### PR TITLE
Increase to 9 gunicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,4 @@ COPY . ./
 # Run production server
 EXPOSE 8000
 ENTRYPOINT [ "tini", "--" ]
-CMD ["gunicorn", "--workers", "5", "--timeout", "120", "--bind", "0.0.0.0:8000", "osuchan.wsgi"]
+CMD ["gunicorn", "--workers", "9", "--timeout", "120", "--bind", "0.0.0.0:8000", "osuchan.wsgi"]


### PR DESCRIPTION
## Why?

We're running on a larger server now, so we can increase the number of workers accordingly.

## Changes

- Increase from 5 to 9 gunicorn workers