### PR TITLE
Move ports out of base compose file

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -12,6 +12,8 @@ services:
   api:
     build:
       target: development-runner
+    ports:
+      - 8000:8000
     volumes:
       - .:/app
 
@@ -25,6 +27,8 @@ services:
   worker_monitor:
     build:
       target: development-runner
+    ports:
+      - 5555:5555
     volumes:
       - .:/app
 
@@ -38,6 +42,10 @@ services:
   prometheus:
     ports:
       - 9090:9090
+
+  grafana:
+    ports:
+      - 3001:3000
 
   difficalcy-osu:
     ports:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -13,6 +13,8 @@ services:
   api:
     build:
       target: production-runner
+    ports:
+      - 8000:8000
     restart: always
 
   worker:
@@ -23,6 +25,8 @@ services:
   worker_monitor:
     build:
       target: production-runner
+    ports:
+      - 5555:5555
     restart: always
 
   scheduler:
@@ -34,6 +38,8 @@ services:
     restart: always
 
   grafana:
+    ports:
+      - 3000:3000
     restart: always
 
   difficalcy-osu:

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,8 +41,6 @@ services:
 
   api:
     build: .
-    ports:
-      - 8000:8000
     env_file:
       - config/active/django.env
     volumes:
@@ -78,8 +76,6 @@ services:
   worker_monitor:
     build: .
     command: celery --app osuchan flower
-    ports:
-      - 5555:5555
     env_file:
       - config/active/django.env
       - config/active/flower.env
@@ -106,8 +102,6 @@ services:
 
   grafana:
     image: grafana/grafana:12.0.2
-    ports:
-      - 3001:3000
     env_file:
       - ./config/active/grafana.env
     volumes:


### PR DESCRIPTION
## Why?

Ports should not be exposed by default.

## Changes

- Move port definitions to dev and prod override files