### PR TITLE
Use common renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "schedule:weekly"
+    "github>Syriiin/renovate-config"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Why?

Easier cross-repo management.

## Changes

- Use common renovate config from https://github.com/Syriiin/renovate-config
