### PR TITLE
Remove roundtable scheduled tasks

### DIFF
--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -244,21 +244,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "ppraces.tasks.dispatch_update_all_ppraces",
         "schedule": crontab(minute="*"),  # every minute
     },
-    "update-trt-top-50-members-every-10-minutes": {
-        "task": "profiles.tasks.dispatch_update_community_leaderboard_members",
-        "schedule": crontab(minute="*/10"),
-        "args": (854, 50),
-    },
-    "update-trt-all-members-every-hour": {
-        "task": "profiles.tasks.dispatch_update_community_leaderboard_members",
-        "schedule": crontab(minute="0", hour="*"),
-        "args": (854, 1000),
-    },
-    "update-trt-test-all-members-every-10-minutes": {
-        "task": "profiles.tasks.dispatch_update_community_leaderboard_members",
-        "schedule": crontab(minute="*/10"),
-        "args": (855, 1000),
-    },
 }
 
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -342,7 +342,7 @@ class ScoreQuerySet(models.QuerySet):
         # Mods
         scores = self.all()
         if score_filter.required_mods_json != []:
-            scores = self.filter(mods_json__has_keys=score_filter.required_mods_json)
+            scores = scores.filter(mods_json__has_keys=score_filter.required_mods_json)
         if score_filter.disqualified_mods_json != []:
             scores = scores.exclude(
                 mods_json__has_any_keys=score_filter.disqualified_mods_json


### PR DESCRIPTION
## Why?

The roundtable 2026 is over, so we can remove scheduled the tasks.

## Changes

- Remove TRT 2026 scheduled tasks
- Fix typo
