### PR TITLE
Fix score insert conficts due to concurrent profile update race condition

### DIFF
--- a/config/dev/django.env
+++ b/config/dev/django.env
@@ -1,7 +1,7 @@
 DJANGO_SETTINGS_MODULE='osuchan.settings'
 SECRET_KEY='generatearandomsecretforproduction'
 DEBUG=True
-ALLOWED_HOSTS='["local.syrin.me"]'
+ALLOWED_HOSTS='["local.syrin.me", "localhost"]'
 FRONTEND_URL='https://local.syrin.me:3000'
 
 POSTGRES_DB_NAME='osuchan'

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -76,6 +76,11 @@ def refresh_user_from_api(
 
     user_stats = fetch_user(user_id=user_id, username=username, gamemode=gamemode)
 
+    if user_stats is not None:
+        # Refetch user stats with select_for_update to lock it for the transaction (crude way to prevent multiple simultaneous refreshes for the same user)
+        # TODO: refactor user updating flow to replace this with a properly readable and maintainable locking mechanism
+        UserStats.objects.select_for_update().get(id=user_stats.id)
+
     if user_stats is not None and user_stats.last_updated > (
         datetime.utcnow().replace(tzinfo=timezone.utc)
         - timedelta(seconds=cooldown_seconds)
@@ -230,6 +235,10 @@ def refresh_user_recent_from_api(
     Fetch and update user recent scores
     """
     user_stats = fetch_user(user_id=user_id, gamemode=gamemode)
+
+    # Refetch user stats with select_for_update to lock it for the transaction (crude way to prevent multiple simultaneous refreshes for the same user)
+    # TODO: refactor user updating flow to replace this with a properly readable and maintainable locking mechanism
+    UserStats.objects.select_for_update().get(id=user_stats.id)
 
     if user_stats is None:
         # User does not exist in the db, so return None


### PR DESCRIPTION
## Why?

We've been getting the occasional score conflict on user update for years because of race conditions from multiple profile updates occurring at the same time.
This isn't a great fix, since it's quite unexpected, but without refactoring the update flow to be more reasonable, this is an okay bandaid.

## Changes

- Add crude locking mechanism to prevent simultaneous profile updates
- Add `localhost` to allowed hosts for local dev
