### PR TITLE
Use durable queues

### DIFF
--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -218,6 +218,7 @@ CELERY_TASK_QUEUES = [
         "tasks",
         Exchange("tasks"),
         routing_key="tasks",
+        durable=True,
         queue_arguments={
             "x-max-priority": 10,
         },


### PR DESCRIPTION
## Why?

Transient queues are deprecated in rabbitmq. Durable queues also just make more sense for us.

## Changes

- Set durable=True on kombu queue configs
