### PR TITLE
Allow deprecated nonexcl queues rabbitmq feature

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,7 @@ services:
       - config/active/rabbitmq.env
     volumes:
       - queue-data:/var/lib/rabbitmq:rw
+      - ./config/active/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
 
   cache:
     image: redis:8

--- a/config/dev/rabbitmq.conf
+++ b/config/dev/rabbitmq.conf
@@ -1,0 +1,1 @@
+deprecated_features.permit.transient_nonexcl_queues = true


### PR DESCRIPTION
## Why?

Seems setting our queues to durable didn't fix it. It could be caused by an internal queue or other.
Either way I want to replace rabbitmq with redis as the broker soon, so it's not a big deal.

## Changes

- Enable deprecated nonexcl queues rabbitmq feature
