### PR TITLE
Remove broker api config from flower

### DIFF
--- a/config/dev/flower.env
+++ b/config/dev/flower.env
@@ -1,2 +1,1 @@
 FLOWER_BASIC_AUTH='osuchan:osuchan'
-FLOWER_BROKER_API='http://osuchan:osuchan@queue:15672/api/'


### PR DESCRIPTION
## Why?

Turns out this isn't necessary, it can auto discover.
