### PR TITLE
Add unranked beatmap challenge support

### DIFF
--- a/events/enums.py
+++ b/events/enums.py
@@ -1,3 +1,6 @@
-class BeatmapChallengeType:
+from enum import StrEnum
+
+
+class BeatmapChallengeType(StrEnum):
     BEST_COMBO = "best_combo"
     LOWEST_MISS_COUNT = "lowest_miss_count"

--- a/events/services.py
+++ b/events/services.py
@@ -16,8 +16,8 @@ from leaderboards.enums import LeaderboardAccessType
 from leaderboards.models import Leaderboard, Membership
 from leaderboards.services import create_membership, delete_membership
 from profiles.enums import ScoreMutation, ScoreSet
-from profiles.models import OsuUser, Score, ScoreFilter
-from profiles.services import refresh_user_from_api
+from profiles.models import Beatmap, OsuUser, Score, ScoreFilter
+from profiles.services import refresh_user_from_api, store_beatmap
 
 
 @transaction.atomic
@@ -191,3 +191,28 @@ def update_attendee_challenge_scores(
         BeatmapChallengeScore.objects.filter(
             challenge=beatmap_challenge, user_id=user_id
         ).delete()
+
+
+@transaction.atomic
+def create_beatmap_challenge(
+    event: Event,
+    beatmap_id: int,
+    description: str,
+    gamemode: int,
+    challenge_type: BeatmapChallengeType,
+) -> BeatmapChallenge:
+    """Create a beatmap challenge, storing the beatmap first if it doesn't exist."""
+    if not Beatmap.objects.filter(id=beatmap_id).exists():
+        beatmap = store_beatmap(beatmap_id)
+        if beatmap is None:
+            raise Beatmap.DoesNotExist(
+                f"Beatmap with id {beatmap_id} not found on osu!"
+            )
+
+    return BeatmapChallenge.objects.create(
+        event=event,
+        beatmap_id=beatmap_id,
+        description=description,
+        gamemode=gamemode,
+        challenge_type=challenge_type,
+    )

--- a/events/views.py
+++ b/events/views.py
@@ -18,12 +18,13 @@ from events.serialisers import (
 )
 from events.services import (
     add_event_attendee,
+    create_beatmap_challenge,
     create_event_leaderboard,
     delete_event_leaderboard,
     remove_event_attendee,
     update_event,
 )
-from profiles.models import OsuUser, Score
+from profiles.models import Beatmap, OsuUser, Score
 
 
 class EventList(APIView):
@@ -224,6 +225,57 @@ class BeatmapChallengeList(APIView):
 
         serialiser = BeatmapChallengeSerialiser(challenges, many=True)
         return Response(serialiser.data)
+
+    def post(self, request, slug):
+        """Create a beatmap challenge for an event."""
+        osu_user_id = request.user.osu_user_id
+        if osu_user_id is None:
+            raise PermissionDenied("Must be authenticated with an osu! account.")
+
+        try:
+            event = Event.objects.get(slug=slug)
+        except Event.DoesNotExist:
+            raise NotFound("Event not found.")
+
+        if not event.is_organiser(osu_user_id):
+            raise PermissionDenied("Must be an organiser to manage challenges.")
+
+        beatmap_id = request.data.get("beatmap_id")
+        if beatmap_id is None:
+            raise ParseError("Missing beatmap_id parameter.")
+
+        description = request.data.get("description")
+        if description is None:
+            raise ParseError("Missing description parameter.")
+
+        gamemode = request.data.get("gamemode")
+        if gamemode is None:
+            raise ParseError("Missing gamemode parameter.")
+
+        challenge_type = request.data.get("challenge_type")
+        if challenge_type is None:
+            raise ParseError("Missing challenge_type parameter.")
+
+        try:
+            challenge_type = BeatmapChallengeType(challenge_type)
+        except ValueError:
+            raise ParseError(
+                f"Invalid challenge_type. Must be one of: {BeatmapChallengeType.BEST_COMBO.value}, {BeatmapChallengeType.LOWEST_MISS_COUNT.value}"
+            )
+
+        try:
+            challenge = create_beatmap_challenge(
+                event,
+                beatmap_id=beatmap_id,
+                description=description,
+                gamemode=gamemode,
+                challenge_type=challenge_type,
+            )
+        except Beatmap.DoesNotExist:
+            raise NotFound("Beatmap not found.")
+
+        serialiser = BeatmapChallengeSerialiser(challenge)
+        return Response(serialiser.data, status=status.HTTP_201_CREATED)
 
 
 class BeatmapChallengeScoreList(APIView):

--- a/minigames/services.py
+++ b/minigames/services.py
@@ -238,7 +238,7 @@ def update_minigame_player_scores(player: MinigamePlayer) -> MinigamePlayer:
         mutation=ScoreMutation.NONE,
         date__gte=minigame.start_time,
         date__lte=minigame.end_time,
-        beatmap__status=BeatmapStatus.RANKED,
+        beatmap__status__in=[BeatmapStatus.RANKED, BeatmapStatus.APPROVED],
     )
 
     minigame_scores = [

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -17,6 +17,7 @@ from common.osu.difficultycalculator import (
 )
 from common.osu.enums import BeatmapStatus, BitMods, Gamemode, Mods
 from common.osu.osuapi import OsuApi, ScoreData
+from events.models import Event
 from leaderboards.models import Leaderboard, Membership
 from osuchan.settings import env_settings
 from profiles.enums import ScoreMutation, ScoreResult
@@ -329,6 +330,23 @@ def refresh_beatmaps_from_api(beatmap_ids: Iterable[int]):
                 update_difficulty_calculations(beatmaps, difficulty_calculator)
 
     return beatmaps
+
+
+@transaction.atomic
+def store_beatmap(beatmap_id: int) -> Beatmap | None:
+    """Fetch and store a beatmap from the osu API regardless of its status."""
+    osu_api = OsuApi()
+    beatmap_data = osu_api.get_beatmap(beatmap_id)
+    if beatmap_data is None:
+        return None
+    beatmap = Beatmap.from_data(beatmap_data)
+    beatmap.save()
+    for difficulty_calculator_class in get_difficulty_calculators_for_gamemode(
+        beatmap.gamemode
+    ):
+        with difficulty_calculator_class() as difficulty_calculator:
+            update_difficulty_calculations([beatmap], difficulty_calculator)
+    return beatmap
 
 
 @transaction.atomic


### PR DESCRIPTION
## Why?

We haven't supported unranked scores before, but the osu API actually only reports unranked scores when played on the latest version of the map. so we can theoretically treat them the same as loved and be okay.

For this MVP we will ignore the invalidation problem, since it'll only be used for a controlled use case, but this needs to be addressed later.

## Changes

- Add ability to create beatmap challenges for unranked beatmaps
- Unranked beatmaps can be added to the db and score for those maps will be collected
- Existing functionality already filters to only ranked maps correctly
- Fix minigames not treating approved maps as ranked