### PR TITLE
Fix potential deadlocks in minigame updates

### DIFF
--- a/minigames/services.py
+++ b/minigames/services.py
@@ -229,6 +229,7 @@ def update_minigame_player_scores(player: MinigamePlayer) -> MinigamePlayer:
     """
     Updates scores for a single minigame player.
     """
+    player = MinigamePlayer.objects.select_for_update().get(id=player.id)
     team = player.team
     minigame = team.minigame
 


### PR DESCRIPTION
## Why?

Deadlocks are no fun

## Changes

- Add row locking to prevent deadlocks in minigame
