### PR TITLE
Always use new lazer scoring for scores

### DIFF
--- a/common/osu/osuapi.py
+++ b/common/osu/osuapi.py
@@ -721,7 +721,7 @@ class LiveOsuApiV2(AbstractOsuApi):
             mods=bitwise_mods,
             mods_json=mods_json,
             is_stable=is_stable,
-            score=score.legacy_total_score if is_stable else score.total_score,
+            score=score.score.total_score,
             best_combo=score.max_combo,
             count_300=count_300,
             count_100=count_100,


### PR DESCRIPTION
## Why?

We actually use score now, and we need lazer and stable to be comparable.

## Changes

- Use lazer score for new scores
