### PR TITLE
Add score streaming for minigames and events

### DIFF
--- a/common/osu/osuapi.py
+++ b/common/osu/osuapi.py
@@ -24,6 +24,11 @@ class MalformedResponseError(Exception):
     pass
 
 
+class ScoresPage(NamedTuple):
+    scores: list[ScoreData]
+    cursor_string: str | None
+
+
 class BeatmapData(NamedTuple):
     beatmap_id: int
     set_id: int
@@ -296,6 +301,9 @@ class ScoreData(NamedTuple):
     rank: str
     date: datetime
 
+    user_id: int
+    gamemode: Gamemode
+
     def as_json(self):
         return {
             "beatmap_id": self.beatmap_id,
@@ -314,10 +322,12 @@ class ScoreData(NamedTuple):
             "perfect": self.perfect,
             "rank": self.rank,
             "date": self.date.isoformat(),
+            "user_id": self.user_id,
+            "gamemode": self.gamemode.value,
         }
 
     @classmethod
-    def from_json(cls, data: dict) -> "ScoreData":
+    def from_json(cls, data: dict, user_id: int, gamemode: Gamemode) -> "ScoreData":
         return cls(
             beatmap_id=data["beatmap_id"],
             mods=data["mods"],
@@ -335,6 +345,8 @@ class ScoreData(NamedTuple):
             perfect=data["perfect"],
             rank=data["rank"],
             date=datetime.fromisoformat(data["date"]),
+            user_id=user_id,
+            gamemode=gamemode,
         )
 
     @classmethod
@@ -409,6 +421,8 @@ class ScoreData(NamedTuple):
             date=datetime.strptime(data["date"], "%Y-%m-%d %H:%M:%S").replace(
                 tzinfo=timezone.utc
             ),
+            user_id=int(data["user_id"]),
+            gamemode=gamemode,
         )
 
 
@@ -439,6 +453,10 @@ class AbstractOsuApi(ABC):
     def get_user_recent_scores(
         self, user_id: int, gamemode: Gamemode
     ) -> list[ScoreData]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_recent_scores(self, cursor_string: str | None = None) -> ScoresPage:
         raise NotImplementedError()
 
 
@@ -515,6 +533,9 @@ class LiveOsuApiV1(AbstractOsuApi):
                 "get_user_recent", u=user_id, type="id", m=gamemode.value, limit=50
             )
         ]
+
+    def get_recent_scores(self, cursor_string: str | None = None) -> ScoresPage:
+        raise NotImplementedError("v1 api does not support the /scores endpoint")
 
 
 class LiveOsuApiV2(AbstractOsuApi):
@@ -594,8 +615,10 @@ class LiveOsuApiV2(AbstractOsuApi):
 
     @staticmethod
     def __score_data_from_ossapi(
-        score: Score, gamemode: Gamemode, beatmap_id_override: int | None = None
+        score: Score, beatmap_id_override: int | None = None
     ) -> ScoreData:
+        gamemode = Gamemode(score.ruleset_id)
+
         if beatmap_id_override is None:
             if score.beatmap is None:
                 raise MalformedResponseError("Score does not have a beatmap")
@@ -733,6 +756,8 @@ class LiveOsuApiV2(AbstractOsuApi):
             perfect=score.legacy_perfect,
             rank=score.rank.value,
             date=score.ended_at,
+            user_id=score.user_id,
+            gamemode=gamemode,
         )
 
     def get_beatmap(self, beatmap_id: int) -> BeatmapData | None:
@@ -783,10 +808,7 @@ class LiveOsuApiV2(AbstractOsuApi):
         except ValueError:
             return []
 
-        return [
-            self.__score_data_from_ossapi(score, gamemode, beatmap_id)
-            for score in scores
-        ]
+        return [self.__score_data_from_ossapi(score, beatmap_id) for score in scores]
 
     def get_user_best_scores(self, user_id: int, gamemode: Gamemode) -> list[ScoreData]:
         try:
@@ -802,7 +824,7 @@ class LiveOsuApiV2(AbstractOsuApi):
         except ValueError:
             return []
 
-        return [self.__score_data_from_ossapi(score, gamemode) for score in scores]
+        return [self.__score_data_from_ossapi(score) for score in scores]
 
     def get_user_recent_scores(
         self, user_id: int, gamemode: Gamemode
@@ -820,7 +842,29 @@ class LiveOsuApiV2(AbstractOsuApi):
         except ValueError:
             return []
 
-        return [self.__score_data_from_ossapi(score, gamemode) for score in scores]
+        return [self.__score_data_from_ossapi(score) for score in scores]
+
+    def get_recent_scores(self, cursor_string: str | None = None) -> ScoresPage:
+        try:
+            scores = self.client.scores(cursor_string=cursor_string)
+            osuapi_requests_counter.labels(
+                endpoint="recent_scores", api_version="v2"
+            ).inc()
+        except ValueError:
+            return ScoresPage(scores=[], cursor_string=None)
+
+        score_data_list = []
+        for score in scores.scores:
+            try:
+                score_data_list.append(
+                    self.__score_data_from_ossapi(
+                        score, beatmap_id_override=score.beatmap_id
+                    )
+                )
+            except ValueError:
+                continue
+
+        return ScoresPage(scores=score_data_list, cursor_string=scores.cursor_string)
 
 
 class StubOsuApi(AbstractOsuApi):
@@ -886,7 +930,7 @@ class StubOsuApi(AbstractOsuApi):
     ) -> list[ScoreData]:
         try:
             return [
-                ScoreData.from_json(data)
+                ScoreData.from_json(data, user_id, gamemode)
                 for data in self.__load_stub_data("scores.json")[str(user_id)][
                     str(gamemode.value)
                 ][str(beatmap_id)]
@@ -897,7 +941,7 @@ class StubOsuApi(AbstractOsuApi):
     def get_user_best_scores(self, user_id: int, gamemode: Gamemode) -> list[ScoreData]:
         try:
             return [
-                ScoreData.from_json(data)
+                ScoreData.from_json(data, user_id, gamemode)
                 for data in self.__load_stub_data("user_best.json")[str(user_id)][
                     str(gamemode.value)
                 ]
@@ -910,13 +954,33 @@ class StubOsuApi(AbstractOsuApi):
     ) -> list[ScoreData]:
         try:
             return [
-                ScoreData.from_json(data)
+                ScoreData.from_json(data, user_id, gamemode)
                 for data in self.__load_stub_data("user_recent.json")[str(user_id)][
                     str(gamemode.value)
                 ]
             ]
         except KeyError:
             return []
+
+    def get_recent_scores(self, cursor_string: str | None = None) -> ScoresPage:
+        if cursor_string is not None:
+            return ScoresPage(scores=[], cursor_string=cursor_string)
+
+        raw_scores = self.__load_json_data(
+            os.path.join(
+                os.path.dirname(__file__),
+                "stubdata",
+                "osuapi",
+                "recent_scores.json",
+            )
+        )
+        return ScoresPage(
+            scores=[
+                ScoreData.from_json(data, data["user_id"], Gamemode(data["gamemode"]))
+                for data in raw_scores
+            ],
+            cursor_string="complete",
+        )
 
 
 OsuApi: Type[AbstractOsuApi] = import_string(settings.OSU_API_CLASS)

--- a/common/osu/stubdata/osuapi/recent_scores.json
+++ b/common/osu/stubdata/osuapi/recent_scores.json
@@ -1,0 +1,602 @@
+[
+    {
+        "beatmap_id": 362949,
+        "mods": 72,
+        "mods_json": {
+            "HD": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 3502092,
+        "best_combo": 404,
+        "count_300": 278,
+        "count_100": 12,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 7,
+        "count_geki": 51,
+        "statistics": {
+            "great": 278,
+            "ok": 12
+        },
+        "perfect": true,
+        "rank": "SH",
+        "date": "2017-06-17T11:10:36+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 2,
+        "mods_json": {
+            "EZ": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 1602032,
+        "best_combo": 404,
+        "count_300": 289,
+        "count_100": 1,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 1,
+        "count_geki": 57,
+        "statistics": {
+            "great": 289,
+            "ok": 1
+        },
+        "perfect": true,
+        "rank": "S",
+        "date": "2017-12-21T13:57:17+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 1386221,
+        "mods": 0,
+        "mods_json": {
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 883194,
+        "best_combo": 268,
+        "count_300": 212,
+        "count_100": 9,
+        "count_50": 1,
+        "count_miss": 4,
+        "count_katu": 36,
+        "count_geki": 458,
+        "statistics": {
+            "perfect": 458,
+            "great": 212,
+            "good": 36,
+            "ok": 9,
+            "meh": 1,
+            "miss": 4
+        },
+        "perfect": false,
+        "rank": "S",
+        "date": "2018-03-12T11:42:52+00:00",
+        "user_id": 5701575,
+        "gamemode": 3
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1097,
+        "mods_json": {
+            "NF": {},
+            "HD": {},
+            "DT": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 214157,
+        "best_combo": 52,
+        "count_300": 234,
+        "count_100": 23,
+        "count_50": 7,
+        "count_miss": 26,
+        "count_katu": 12,
+        "count_geki": 29,
+        "statistics": {
+            "great": 234,
+            "ok": 23,
+            "meh": 7,
+            "miss": 26
+        },
+        "perfect": false,
+        "rank": "B",
+        "date": "2018-03-28T15:24:17+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1089,
+        "mods_json": {
+            "NF": {},
+            "DT": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 334024,
+        "best_combo": 103,
+        "count_300": 264,
+        "count_100": 8,
+        "count_50": 6,
+        "count_miss": 12,
+        "count_katu": 4,
+        "count_geki": 41,
+        "statistics": {
+            "great": 264,
+            "ok": 8,
+            "meh": 6,
+            "miss": 12
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2018-03-28T15:26:07+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1032,
+        "mods_json": {
+            "HD": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 870281,
+        "best_combo": 119,
+        "count_300": 282,
+        "count_100": 4,
+        "count_50": 0,
+        "count_miss": 4,
+        "count_katu": 3,
+        "count_geki": 52,
+        "statistics": {
+            "great": 282,
+            "ok": 4,
+            "miss": 4
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2019-01-30T13:07:44+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1600,
+        "mods_json": {
+            "NC": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 681752,
+        "best_combo": 128,
+        "count_300": 238,
+        "count_100": 37,
+        "count_50": 4,
+        "count_miss": 11,
+        "count_katu": 16,
+        "count_geki": 34,
+        "statistics": {
+            "great": 238,
+            "ok": 37,
+            "meh": 4,
+            "miss": 11
+        },
+        "perfect": false,
+        "rank": "B",
+        "date": "2019-09-03T11:10:14+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1026,
+        "mods_json": {
+            "EZ": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 302882,
+        "best_combo": 94,
+        "count_300": 259,
+        "count_100": 4,
+        "count_50": 1,
+        "count_miss": 26,
+        "count_katu": 2,
+        "count_geki": 44,
+        "statistics": {
+            "great": 259,
+            "ok": 4,
+            "meh": 1,
+            "miss": 26
+        },
+        "perfect": false,
+        "rank": "B",
+        "date": "2020-04-03T08:27:31+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1024,
+        "mods_json": {
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 2475834,
+        "best_combo": 342,
+        "count_300": 283,
+        "count_100": 6,
+        "count_50": 0,
+        "count_miss": 1,
+        "count_katu": 4,
+        "count_geki": 53,
+        "statistics": {
+            "great": 283,
+            "ok": 6,
+            "miss": 1
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2020-04-03T08:50:47+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 1088,
+        "mods_json": {
+            "DT": {},
+            "FL": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 1060393,
+        "best_combo": 180,
+        "count_300": 263,
+        "count_100": 15,
+        "count_50": 3,
+        "count_miss": 9,
+        "count_katu": 8,
+        "count_geki": 43,
+        "statistics": {
+            "great": 263,
+            "ok": 15,
+            "meh": 3,
+            "miss": 9
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2020-04-03T08:54:41+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 307618,
+        "mods": 104,
+        "mods_json": {
+            "HD": {},
+            "SD": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 137805806,
+        "best_combo": 2757,
+        "count_300": 1739,
+        "count_100": 14,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 7,
+        "count_geki": 360,
+        "statistics": {
+            "great": 1739,
+            "ok": 14
+        },
+        "perfect": false,
+        "rank": "SH",
+        "date": "2020-08-15T14:12:14+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 264364,
+        "mods": 104,
+        "mods_json": {
+            "HD": {},
+            "SD": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 4543964,
+        "best_combo": 448,
+        "count_300": 346,
+        "count_100": 1,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 1,
+        "count_geki": 73,
+        "statistics": {
+            "great": 346,
+            "ok": 1
+        },
+        "perfect": true,
+        "rank": "SH",
+        "date": "2020-08-15T14:50:41+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 323769,
+        "mods": 104,
+        "mods_json": {
+            "HD": {},
+            "SD": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 10001459,
+        "best_combo": 645,
+        "count_300": 540,
+        "count_100": 0,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 0,
+        "count_geki": 101,
+        "statistics": {
+            "great": 540
+        },
+        "perfect": true,
+        "rank": "XH",
+        "date": "2021-03-08T14:05:52+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 74,
+        "mods_json": {
+            "EZ": {},
+            "HD": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 1078214,
+        "best_combo": 311,
+        "count_300": 274,
+        "count_100": 2,
+        "count_50": 0,
+        "count_miss": 14,
+        "count_katu": 1,
+        "count_geki": 52,
+        "statistics": {
+            "great": 274,
+            "ok": 2,
+            "miss": 14
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2023-04-18T14:50:34+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 362949,
+        "mods": 66,
+        "mods_json": {
+            "EZ": {},
+            "DT": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 1718512,
+        "best_combo": 404,
+        "count_300": 279,
+        "count_100": 11,
+        "count_50": 0,
+        "count_miss": 0,
+        "count_katu": 6,
+        "count_geki": 52,
+        "statistics": {
+            "great": 279,
+            "ok": 11
+        },
+        "perfect": true,
+        "rank": "S",
+        "date": "2023-04-18T14:59:33+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 638017,
+        "mods": 24,
+        "mods_json": {
+            "HD": {},
+            "HR": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 9393700,
+        "best_combo": 707,
+        "count_300": 537,
+        "count_100": 58,
+        "count_50": 1,
+        "count_miss": 1,
+        "count_katu": 29,
+        "count_geki": 104,
+        "statistics": {
+            "great": 537,
+            "ok": 58,
+            "meh": 1,
+            "miss": 1
+        },
+        "perfect": false,
+        "rank": "B",
+        "date": "2023-05-30T13:24:21+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 1117451,
+        "mods": 8,
+        "mods_json": {
+            "HD": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 2572332,
+        "best_combo": 174,
+        "count_300": 731,
+        "count_100": 33,
+        "count_50": 2,
+        "count_miss": 32,
+        "count_katu": 22,
+        "count_geki": 167,
+        "statistics": {
+            "great": 731,
+            "ok": 33,
+            "meh": 2,
+            "miss": 32
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2023-05-31T11:51:16+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 209276,
+        "mods": 8,
+        "mods_json": {
+            "HD": {},
+            "CL": {}
+        },
+        "is_stable": true,
+        "score": 1881030,
+        "best_combo": 294,
+        "count_300": 337,
+        "count_100": 14,
+        "count_50": 0,
+        "count_miss": 10,
+        "count_katu": 7,
+        "count_geki": 57,
+        "statistics": {
+            "great": 337,
+            "ok": 14,
+            "miss": 10
+        },
+        "perfect": false,
+        "rank": "F",
+        "date": "2023-05-31T12:02:04+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 422328,
+        "mods": 0,
+        "mods_json": {},
+        "is_stable": false,
+        "score": 548961,
+        "best_combo": 127,
+        "count_300": 333,
+        "count_100": 13,
+        "count_50": 0,
+        "count_miss": 14,
+        "count_katu": 0,
+        "count_geki": 0,
+        "statistics": {
+            "ok": 13,
+            "miss": 14,
+            "great": 333,
+            "ignore_hit": 149,
+            "ignore_miss": 8,
+            "large_bonus": 3,
+            "small_bonus": 21,
+            "large_tick_hit": 26,
+            "slider_tail_hit": 149
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2024-11-22T09:43:15+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 386728,
+        "mods": 64,
+        "mods_json": {
+            "DT": {
+                "speed_change": 1.01
+            }
+        },
+        "is_stable": false,
+        "score": 527683,
+        "best_combo": 269,
+        "count_300": 1276,
+        "count_100": 69,
+        "count_50": 0,
+        "count_miss": 20,
+        "count_katu": 0,
+        "count_geki": 0,
+        "statistics": {
+            "ok": 69,
+            "miss": 20,
+            "great": 1276,
+            "ignore_hit": 332,
+            "ignore_miss": 9,
+            "large_tick_hit": 40,
+            "slider_tail_hit": 327
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2024-12-14T11:41:59+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    },
+    {
+        "beatmap_id": 386728,
+        "mods": 0,
+        "mods_json": {
+            "CL": {}
+        },
+        "is_stable": false,
+        "score": 527683,
+        "best_combo": 269,
+        "count_300": 1276,
+        "count_100": 69,
+        "count_50": 0,
+        "count_miss": 20,
+        "count_katu": 0,
+        "count_geki": 0,
+        "statistics": {
+            "ok": 69,
+            "miss": 20,
+            "great": 1276,
+            "ignore_hit": 332,
+            "ignore_miss": 9,
+            "large_tick_hit": 40,
+            "slider_tail_hit": 327
+        },
+        "perfect": false,
+        "rank": "A",
+        "date": "2024-12-14T11:42:00+00:00",
+        "user_id": 5701575,
+        "gamemode": 0
+    }
+]

--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -241,6 +241,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "ppraces.tasks.dispatch_update_all_ppraces",
         "schedule": crontab(minute="*"),  # every minute
     },
+    "ingest-recent-scores-every-10s": {
+        "task": "profiles.tasks.ingest_recent_scores",
+        "schedule": timedelta(seconds=10),
+    },
     "update-minigames-every-minute": {
         "task": "minigames.tasks.dispatch_minigame_updates",
         "schedule": crontab(minute="*"),  # every minute

--- a/profiles/services.py
+++ b/profiles/services.py
@@ -1,7 +1,9 @@
 import itertools
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Iterable
 
+from django.core.cache import cache
 from django.db import transaction
 from prometheus_client import Counter
 
@@ -19,6 +21,8 @@ from common.osu.enums import BeatmapStatus, BitMods, Gamemode, Mods
 from common.osu.osuapi import OsuApi, ScoreData
 from events.models import Event
 from leaderboards.models import Leaderboard, Membership
+from minigames.enums import MinigameStatus
+from minigames.models import Minigame, MinigamePlayer
 from osuchan.settings import env_settings
 from profiles.enums import ScoreMutation, ScoreResult
 from profiles.models import (
@@ -37,6 +41,11 @@ scores_added_counter = Counter(
     "Total number of real scores (non-mutations) added to the database",
     ["gamemode"],
 )
+
+logger = logging.getLogger(__name__)
+
+OSU_SCORES_CURSOR_CACHE_KEY = "osu_scores_cursor"
+OSU_SCORES_MAX_STREAM_PAGES = 10
 
 
 def fetch_user(user_id=None, username=None, gamemode=Gamemode.STANDARD):
@@ -739,3 +748,104 @@ def calculate_performance_values(
     ]
 
     return values
+
+
+def ingest_scores_from_stream() -> list[Score]:
+    """
+    Poll for latest scores using the stored cursor, and update the cursor.
+    """
+    osu_api = OsuApi()
+    cursor = cache.get(OSU_SCORES_CURSOR_CACHE_KEY)
+
+    streamed_scores = []
+    pages_fetched = 0
+    while True:
+        page = osu_api.get_recent_scores(cursor_string=cursor)
+        if page.cursor_string is None:
+            logger.warning(
+                "Failed to fetch new scores from the osu! /scores stream; keeping cursor"
+            )
+            return []
+        streamed_scores.extend(page.scores)
+        pages_fetched += 1
+        cache.set(OSU_SCORES_CURSOR_CACHE_KEY, page.cursor_string)
+        if cursor is None or page.cursor_string == cursor or len(page.scores) < 1000:
+            break
+        if pages_fetched >= OSU_SCORES_MAX_STREAM_PAGES:
+            logger.warning(
+                "Reached the %d page limit for the /scores stream; dropping backlog and resetting cursor",
+                OSU_SCORES_MAX_STREAM_PAGES,
+            )
+            cache.delete(OSU_SCORES_CURSOR_CACHE_KEY)
+            return []
+        cursor = page.cursor_string
+
+    tracked_user_ids = get_tracked_user_ids()
+
+    scores_by_user: dict[tuple[int, Gamemode], list] = {}
+    for score in streamed_scores:
+        if score.user_id in tracked_user_ids[score.gamemode.value]:
+            scores_by_user.setdefault((score.user_id, score.gamemode), []).append(score)
+
+    created_scores: list[Score] = []
+    for (user_id, gamemode), user_scores in scores_by_user.items():
+        try:
+            with transaction.atomic():
+                user_stats = (
+                    UserStats.objects.select_for_update()
+                    .filter(user_id=user_id, gamemode=gamemode)
+                    .first()
+                )
+                if user_stats is None:
+                    continue
+
+                new_scores = add_scores_from_data(user_stats, user_scores)
+
+                if len(new_scores) > 0:
+                    for (
+                        difficulty_calculator_class
+                    ) in get_difficulty_calculators_for_gamemode(gamemode):
+                        with difficulty_calculator_class() as difficulty_calculator:
+                            update_performance_calculations(
+                                new_scores, difficulty_calculator
+                            )
+                    user_stats.recalculate()
+                    user_stats.save()
+        except Exception:
+            logger.exception(
+                "Failed to ingest %d streamed scores for user %s (gamemode %s)",
+                len(user_scores),
+                user_id,
+                gamemode.value,
+            )
+            continue
+
+        created_scores.extend(new_scores)
+
+    return created_scores
+
+
+def get_tracked_user_ids() -> dict[int, set[int]]:
+    """
+    Returns a mapping of gamemode value -> set of osu user ids whose streamed scores we want to ingest.
+    """
+    tracked_user_ids = {gamemode.value: set() for gamemode in Gamemode}
+
+    now = datetime.now(tz=timezone.utc)
+
+    # Players in active minigames, per the minigame's gamemode
+    active_minigames = Minigame.objects.exclude(status=MinigameStatus.FINISHED)
+    for gamemode, user_id in MinigamePlayer.objects.filter(
+        team__minigame__in=active_minigames
+    ).values_list("team__minigame__gamemode", "user_id"):
+        tracked_user_ids[gamemode].add(user_id)
+
+    # Attendees of active events
+    active_events = Event.objects.filter(start_date__lte=now, end_date__gte=now)
+    event_user_ids = set(active_events.values_list("attendees__id", flat=True))
+    event_user_ids.discard(None)
+    for user_id in event_user_ids:
+        for gamemode in tracked_user_ids:
+            tracked_user_ids[gamemode].add(user_id)
+
+    return tracked_user_ids

--- a/profiles/tasks.py
+++ b/profiles/tasks.py
@@ -5,14 +5,16 @@ from celery import shared_task
 
 from common.osu.beatmap_provider import BeatmapProvider
 from common.osu.enums import BeatmapStatus, Gamemode
+from common.osu.osuapi import OsuApi
 from events.tasks import update_user_event_challenge_scores
 from leaderboards.enums import LeaderboardAccessType
 from leaderboards.models import Leaderboard
 from leaderboards.tasks import update_memberships
 from minigames.tasks import update_minigame_players_scores
 from ppraces.tasks import update_pprace_players
-from profiles.models import Beatmap, OsuUser
+from profiles.models import Beatmap, OsuUser, UserStats
 from profiles.services import (
+    ingest_scores_from_stream,
     refresh_beatmaps_from_api,
     refresh_user_from_api,
     refresh_user_recent_from_api,
@@ -170,3 +172,23 @@ def update_loved_beatmaps():
                 f"Deleting {outdated_scores.count()} outdated scores for beatmap {beatmap.id}"
             )
             outdated_scores.delete()
+
+
+@shared_task(priority=8)
+def ingest_recent_scores():
+    """
+    Poll for latest scores for all gamemodes, storing those we care about.
+    """
+    created_scores = ingest_scores_from_stream()
+    if len(created_scores) == 0:
+        return
+
+    updated_users = set(
+        UserStats.objects.filter(
+            id__in=[score.user_stats_id for score in created_scores]
+        ).values_list("user_id", "gamemode")
+    )
+    for user_id, gamemode in updated_users:
+        update_memberships.delay(user_id=user_id, gamemode=gamemode)
+        update_pprace_players.delay(user_id=user_id, gamemode=gamemode)
+        update_minigame_players_scores.delay(user_id=user_id, gamemode=gamemode)

--- a/profiles/test_services.py
+++ b/profiles/test_services.py
@@ -1,13 +1,25 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
+from django.core.cache import cache
 
 from common.osu.difficultycalculator import get_default_difficulty_calculator_class
 from common.osu.enums import BitMods, Gamemode
-from profiles.models import DifficultyCalculation, PerformanceCalculation
+from events.models import Event
+from profiles.models import (
+    DifficultyCalculation,
+    OsuUser,
+    PerformanceCalculation,
+    Score,
+    UserStats,
+)
 from profiles.services import (
+    OSU_SCORES_CURSOR_CACHE_KEY,
     calculate_difficulty_values,
     calculate_performance_values,
     fetch_scores,
     fetch_user,
+    ingest_scores_from_stream,
     refresh_user_from_api,
     update_difficulty_calculations,
     update_performance_calculations,
@@ -221,3 +233,61 @@ class TestDifficultyCalculationServices:
         assert performance_values[0][4].value == 48.926436544789105
         assert performance_values[0][5].name == "total"
         assert performance_values[0][5].value == 764.5177081010385
+
+
+@pytest.mark.django_db
+class TestIngestScoresFromStream:
+    def test_stream_populates_db_and_updates_user_stats(self):
+        cache.delete(OSU_SCORES_CURSOR_CACHE_KEY)
+
+        osu_user = OsuUser.objects.create(
+            id=5701575,
+            username="Syrin",
+            country="au",
+            join_date=datetime(2017, 1, 1, tzinfo=timezone.utc),
+            disabled=False,
+        )
+        user_stats = UserStats.objects.create(
+            user=osu_user,
+            gamemode=Gamemode.STANDARD,
+            playcount=0,
+            playtime=0,
+            level=0,
+            ranked_score=0,
+            total_score=0,
+            rank=0,
+            country_rank=0,
+            pp=0,
+            accuracy=0,
+            count_300=0,
+            count_100=0,
+            count_50=0,
+            count_rank_ss=0,
+            count_rank_ssh=0,
+            count_rank_s=0,
+            count_rank_sh=0,
+            count_rank_a=0,
+            last_updated=datetime.now(tz=timezone.utc),
+        )
+
+        now = datetime.now(tz=timezone.utc)
+        event = Event.objects.create(
+            slug="test-event",
+            name="Test Event",
+            start_date=now - timedelta(days=1),
+            end_date=now + timedelta(days=1),
+            creation_time=now,
+        )
+        event.attendees.add(osu_user)
+
+        ingest_scores_from_stream()
+
+        user_stats.refresh_from_db()
+        assert Score.objects.filter(user_stats=user_stats).count() > 0
+        assert PerformanceCalculation.objects.filter(
+            score__user_stats=user_stats
+        ).exists()
+        assert user_stats.score_style_accuracy != 0
+        assert user_stats.score_style_bpm != 0
+
+        cache.delete(OSU_SCORES_CURSOR_CACHE_KEY)


### PR DESCRIPTION
## Why?

Polling for recent scores by user has treated us well up to now, and will remain the main source of scores for now, but for minigames specifically (and events to a lesser extent), it'll be nice to have a more speedy score delivery method.
If this method scales well, we can expand it to other use cases too.

## Changes

- Add score streaming every 10s with the new-ish osu api `/scores` endpoint and cursor paging
