### PR TITLE
Bump score stream priority

### DIFF
--- a/profiles/tasks.py
+++ b/profiles/tasks.py
@@ -174,7 +174,7 @@ def update_loved_beatmaps():
             outdated_scores.delete()
 
 
-@shared_task(priority=8)
+@shared_task(priority=2)
 def ingest_recent_scores():
     """
     Poll for latest scores for all gamemodes, storing those we care about.


### PR DESCRIPTION
## Why?

We just made this improvement, we dont want it drowning in attendee update tasks.

## Changes

- Bump score stream priority to 2
