### PR TITLE
Increase minigame update schedule to every 10s

### DIFF
--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -239,7 +239,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-ppraces-every-minute": {
         "task": "ppraces.tasks.dispatch_update_all_ppraces",
-        "schedule": crontab(minute="*"),  # every minute
+        "schedule": timedelta(seconds=10),
     },
     "ingest-recent-scores-every-10s": {
         "task": "profiles.tasks.ingest_recent_scores",
@@ -247,7 +247,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-minigames-every-minute": {
         "task": "minigames.tasks.dispatch_minigame_updates",
-        "schedule": crontab(minute="*"),  # every minute
+        "schedule": timedelta(seconds=10),
     },
     "update-event-attendees-every-hour": {
         "task": "events.tasks.dispatch_update_all_current_event_attendees",


### PR DESCRIPTION
## Why?

These are very cheap operations, and we collect scores much more frequently now, so we can afford to trigger these more frequently.

## Changes

- Increase minigame and pprace update schedule from every minute to every 10s
