### PR TITLE
Remove COE scheduled tasks

### DIFF
--- a/osuchan/settings.py
+++ b/osuchan/settings.py
@@ -261,26 +261,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "events.tasks.dispatch_update_all_current_event_stats",
         "schedule": crontab(minute="*/10"),  # every 10 minutes
     },
-    "send-coe-podium-osu-every-day": {
-        "task": "leaderboards.tasks.send_leaderboard_podium_notification",
-        "schedule": crontab(minute="0", hour="16"),  # 18:00 netherlands time
-        "args": (864,),
-    },
-    "send-coe-podium-taiko-every-day": {
-        "task": "leaderboards.tasks.send_leaderboard_podium_notification",
-        "schedule": crontab(minute="0", hour="16"),  # 18:00 netherlands time
-        "args": (865,),
-    },
-    "send-coe-podium-catch-every-day": {
-        "task": "leaderboards.tasks.send_leaderboard_podium_notification",
-        "schedule": crontab(minute="0", hour="16"),  # 18:00 netherlands time
-        "args": (866,),
-    },
-    "send-coe-podium-mania-every-day": {
-        "task": "leaderboards.tasks.send_leaderboard_podium_notification",
-        "schedule": crontab(minute="0", hour="16"),  # 18:00 netherlands time
-        "args": (867,),
-    },
 }
 
 


### PR DESCRIPTION
## Why?

COE is over :(

Hopefully this is the last year we'll need these bespoke tasks now that the event system is maturing.

## Changes

- Remove COE scheduled tasks